### PR TITLE
Disable docs.vanillaframework.io; add other disabled domains

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -105,7 +105,7 @@
                         <td class="commit">...</td>
                         <td class="human-time">...</td>
                         <td>
-                            <a style="width: 100%" class="p-button--neutral"
+                            <a class="p-button--neutral"
                                 href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-docs.staging.vanillaframework.io"
                             >
                                 <small>Deploy to staging</small>
@@ -135,7 +135,7 @@
                         <td class="commit">...</td>
                         <td class="human-time">...</td>
                         <td>
-                            <a style="width: 100%" class="p-button--neutral"
+                            <a class="p-button--neutral"
                                href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-limenet.staging.snapcraft.io"
                             >
                                 <small>Deploy to staging</small>
@@ -179,7 +179,7 @@
                         <td class="commit">...</td>
                         <td class="human-time">...</td>
                         <td>
-                            <a style="width: 100%" class="p-button--neutral"
+                            <a class="p-button--neutral"
                                href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-sdrsatcom.staging.snapcraft.io"
                             >
                                 <small>Deploy to staging</small>

--- a/templates/index.html
+++ b/templates/index.html
@@ -307,13 +307,10 @@
                     let release = domainRow.querySelector('.release');
 
                     if ('error' in domainJson) {
-                        imageTag.setAttribute('colspan', '4');
+                        imageTag.setAttribute('colspan', '3');
                         imageTag.innerHTML = `<small style="color: red; font-style: italic">${domainJson.error}</small>`;
                         commit.remove();
                         humanTime.remove();
-                        if (release) {
-                            release.remove();
-                        }
                     } else {
                         imageTag.innerHTML = `<code>${domainJson['imageTag']}</code>`;
                         commit.innerHTML = `<a href="https://github.com/${domainRepositories[domainJson['domain']]}/commit/${domainJson['commitId']}">${domainJson['commitId']}</a>`;

--- a/templates/index.html
+++ b/templates/index.html
@@ -100,9 +100,21 @@
                         <td class="human-time">...</td>
                         <td class="release">...</td>
                     </tr>
-                    <tr>
-                        <td><a href="https://docs.staging.vanillaframework.io" target="_blank">docs.staging.vanillaframework.io</a></td>
-                        <td class="image-tag" colspan="4">not enabled - see <a href="https://wiki.canonical.com/ProductStrategyTeam/WebDevelopment/Websites">our wiki</a></td>
+                    <tr data-domain="docs.vanillaframework.io">
+                        <td>
+                            <a href="https://docs.staging.vanillaframework.io" target="_blank">docs.staging.vanillaframework.io</a><br />
+                            <small>(not automatically updated)</small>
+                        </td>
+                        <td class="image-tag">...</td>
+                        <td class="commit">...</td>
+                        <td class="human-time">...</td>
+                        <td>
+                            <a style="width: 100%" class="p-button--neutral"
+                                href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-limenet.staging.snapcraft.io"
+                            >
+                                <small>Deploy to staging</small>
+                            </a>
+                        </td>
                     </tr>
                     <tr data-domain="engage.canonical.com">
                         <td><a href="https://engage.staging.canonical.com" target="_blank">engage.staging.canonical.com</a></td>

--- a/templates/index.html
+++ b/templates/index.html
@@ -253,9 +253,11 @@
                 'docs.maas.io': 'CanonicalLtd/maas-docs',
                 'docs.snapcraft.io': 'canonical-web-and-design/docs.snapcraft.io',
                 'docs.ubuntu.com': 'canonical-web-and-design/docs.ubuntu.com',
+                'docs.vanillaframework.io': 'canonical-web-and-design/vanilla-framework',
                 'engage.canonical.com': 'canonical-web-and-design/engage.canonical.com-public-cloud',
                 'jaas.ai': 'canonical-web-and-design/jaas.ai',
                 'jp.ubuntu.com': 'canonical-web-and-design/jp.ubuntu.com',
+                'limenet.snapcraft.io': 'canonical-web-and-design/snapcraft.io',
                 'maas.io': 'canonical-web-and-design/maas.io',
                 'microk8s.io': 'canonical-web-and-design/microk8s.io',
                 'mir-server.io': 'canonical-web-and-design/mir-server.io',
@@ -263,6 +265,7 @@
                 'netplan.io': 'canonical-web-and-design/netplan.io',
                 'old-docs.jujucharms.com': 'juju/docs',
                 'snapcraft.io': 'canonical-web-and-design/snapcraft.io',
+                'sdrsatcom.snapcraft.io': 'canonical-web-and-design/snapcraft.io',
                 'tutorials.ubuntu.com': 'canonical-web-and-design/tutorials.ubuntu.com',
                 'vanillaframework.io': 'canonical-web-and-design/vanillaframework.io'
             };

--- a/templates/index.html
+++ b/templates/index.html
@@ -243,21 +243,9 @@
                         <td><a href="https://tutorials.staging.ubuntu.com" target="_blank">tutorials.staging.ubuntu.com</a></td>
                         <td class="image-tag" colspan="4">not enabled - see <a href="https://wiki.canonical.com/ProductStrategyTeam/WebDevelopment/Websites">our wiki</a></td>
                     </tr>
-                    <tr data-domain="usn.ubuntu.com">
-                        <td>
-                            <a href="https://usn.staging.ubuntu.com" target="_blank">usn.staging.ubuntu.com</a><br />
-                            <small>(not automatically updated)</small>
-                        </td>
-                        <td class="image-tag">...</td>
-                        <td class="commit">...</td>
-                        <td class="human-time">...</td>
-                        <td>
-                            <a style="width: 100%" class="p-button--neutral"
-                               href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-limenet.staging.snapcraft.io"
-                            >
-                                <small>Deploy to staging</small>
-                            </a>
-                        </td>
+                    <tr>
+                        <td><a href="https://usn.staging.ubuntu.com" target="_blank">usn.staging.ubuntu.com</a></td>
+                        <td class="image-tag" colspan="4">not enabled - see <a href="https://wiki.canonical.com/ProductStrategyTeam/WebDevelopment/Websites">our wiki</a></td>
                     </tr>
                     <tr>
                         <td><a href="https://www.staging.canonical.com" target="_blank">www.staging.canonical.com</a></td>

--- a/templates/index.html
+++ b/templates/index.html
@@ -316,9 +316,9 @@
             <h3>Staging domains not yet supported</h3>
 
             <ul>
-                <li><a href="https://assets.ubuntu.com" target="_blank">assets.ubuntu.com</a></li>
-                <li><a href="http://landscape-brochure.internal" target="_blank">landscape-brochure.internal</a></li>
-                <li><a href="https://manager.assets.ubuntu.com" target="_blank">manager.assets.ubuntu.com</a></li>
+                <li><a href="https://assets.staging.ubuntu.com" target="_blank">assets.staging.ubuntu.com</a></li>
+                <li><a href="http://landscape-brochure.staging.internal" target="_blank">landscape-brochure.staging.internal</a></li>
+                <li><a href="https://manager.assets.staging.ubuntu.com" target="_blank">manager.assets.staging.ubuntu.com</a></li>
                 <li><a href="https://partners.staging.ubuntu.com" target="_blank">partners.staging.ubuntu.com</a></li>
                 <li><a href="https://tutorials.staging.ubuntu.com" target="_blank">tutorials.staging.ubuntu.com</a></li>
                 <li><a href="https://usn.staging.ubuntu.com" target="_blank">usn.staging.ubuntu.com</a></li>

--- a/templates/index.html
+++ b/templates/index.html
@@ -33,10 +33,6 @@
                         <td class="human-time">...</td>
                         <td class="release">...</td>
                     </tr>
-                    <tr>
-                        <td><a href="https://assets.ubuntu.com" target="_blank">assets.ubuntu.com</a></td>
-                        <td class="image-tag" colspan="4">not enabled - see <a href="https://wiki.canonical.com/ProductStrategyTeam/WebDevelopment/Websites">our wiki</a></td>
-                    </tr>
                     <tr data-domain="blog.ubuntu.com">
                         <td><a href="https://blog.staging.ubuntu.com" target="_blank">blog.staging.ubuntu.com</a></td>
                         <td class="image-tag">...</td>
@@ -146,14 +142,6 @@
                             </a>
                         </td>
                     </tr>
-                    <tr>
-                        <td><a href="http://landscape-brochure.internal" target="_blank">landscape-brochure.internal</a></td>
-                        <td class="image-tag" colspan="4">not enabled - see <a href="https://wiki.canonical.com/ProductStrategyTeam/WebDevelopment/Websites">our wiki</a></td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://manager.assets.ubuntu.com" target="_blank">manager.assets.ubuntu.com</a></td>
-                        <td class="image-tag" colspan="4">not enabled - see <a href="https://wiki.canonical.com/ProductStrategyTeam/WebDevelopment/Websites">our wiki</a></td>
-                    </tr>
                     <tr data-domain="cloud-init.io">
                         <td><a href="https://staging.cloud-init.io" target="_blank">staging.cloud-init.io</a></td>
                         <td class="image-tag">...</td>
@@ -181,10 +169,6 @@
                         <td class="commit">...</td>
                         <td class="human-time">...</td>
                         <td class="release">...</td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://partners.staging.ubuntu.com" target="_blank">partners.staging.ubuntu.com</a></td>
-                        <td class="image-tag" colspan="4">not enabled - see <a href="https://wiki.canonical.com/ProductStrategyTeam/WebDevelopment/Websites">our wiki</a></td>
                     </tr>
                     <tr data-domain="sdrsatcom.snapcraft.io">
                         <td>
@@ -250,22 +234,6 @@
                         <td class="commit">...</td>
                         <td class="human-time">...</td>
                         <td class="release">...</td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://tutorials.staging.ubuntu.com" target="_blank">tutorials.staging.ubuntu.com</a></td>
-                        <td class="image-tag" colspan="4">not enabled - see <a href="https://wiki.canonical.com/ProductStrategyTeam/WebDevelopment/Websites">our wiki</a></td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://usn.staging.ubuntu.com" target="_blank">usn.staging.ubuntu.com</a></td>
-                        <td class="image-tag" colspan="4">not enabled - see <a href="https://wiki.canonical.com/ProductStrategyTeam/WebDevelopment/Websites">our wiki</a></td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://www.staging.canonical.com" target="_blank">www.staging.canonical.com</a></td>
-                        <td class="image-tag" colspan="4">not enabled - see <a href="https://wiki.canonical.com/ProductStrategyTeam/WebDevelopment/Websites">our wiki</a></td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://www.staging.ubuntu.com" target="_blank">www.staging.ubuntu.com</a></td>
-                        <td class="image-tag" colspan="4">not enabled - see <a href="https://wiki.canonical.com/ProductStrategyTeam/WebDevelopment/Websites">our wiki</a></td>
                     </tr>
                 </table>
             </div>
@@ -335,6 +303,23 @@
                 }
             )
         </script>
+
+        <div class="p-strip is-shallow is-bordered">
+          <div class="row">
+            <h3>Staging domains not yet supported</h3>
+
+            <ul>
+                <li><a href="https://assets.ubuntu.com" target="_blank">assets.ubuntu.com</a></li>
+                <li><a href="http://landscape-brochure.internal" target="_blank">landscape-brochure.internal</a></li>
+                <li><a href="https://manager.assets.ubuntu.com" target="_blank">manager.assets.ubuntu.com</a></li>
+                <li><a href="https://partners.staging.ubuntu.com" target="_blank">partners.staging.ubuntu.com</a></li>
+                <li><a href="https://tutorials.staging.ubuntu.com" target="_blank">tutorials.staging.ubuntu.com</a></li>
+                <li><a href="https://usn.staging.ubuntu.com" target="_blank">usn.staging.ubuntu.com</a></li>
+                <li><a href="https://www.staging.canonical.com" target="_blank">www.staging.canonical.com</a></li>
+                <li><a href="https://www.staging.ubuntu.com" target="_blank">www.staging.ubuntu.com</a></li>
+            </ul>
+          </div>
+        </div>
     </main>
 </body>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -119,11 +119,20 @@
                         <td class="release">...</td>
                     </tr>
                     <tr data-domain="limenet.snapcraft.io">
-                        <td><a href="https://limenet.staging.snapcraft.io" target="_blank">limenet.staging.snapcraft.io</a></td>
+                        <td>
+                            <a href="https://limenet.staging.snapcraft.io" target="_blank">limenet.staging.snapcraft.io</a><br />
+                            <small>(not automatically updated)</small>
+                        </td>
                         <td class="image-tag">...</td>
                         <td class="commit">...</td>
                         <td class="human-time">...</td>
-                        <td class="release">...</td>
+                        <td>
+                            <a style="width: 100%" class="p-button--neutral"
+                               href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-limenet.staging.snapcraft.io"
+                            >
+                                <small>Deploy to staging</small>
+                            </a>
+                        </td>
                     </tr>
                     <tr>
                         <td><a href="http://landscape-brochure.internal" target="_blank">landscape-brochure.internal</a></td>
@@ -166,11 +175,20 @@
                         <td class="image-tag" colspan="4">not enabled - see <a href="https://wiki.canonical.com/ProductStrategyTeam/WebDevelopment/Websites">our wiki</a></td>
                     </tr>
                     <tr data-domain="sdrsatcom.snapcraft.io">
-                        <td><a href="https://sdrsatcom.staging.snapcraft.io" target="_blank">sdrsatcom.staging.snapcraft.io</a></td>
+                        <td>
+                            <a href="https://sdrsatcom.staging.snapcraft.io" target="_blank">sdrsatcom.staging.snapcraft.io</a><br />
+                            <small>(not automatically updated)</small>
+                        </td>
                         <td class="image-tag">...</td>
                         <td class="commit">...</td>
                         <td class="human-time">...</td>
-                        <td class="release">...</td>
+                        <td>
+                            <a style="width: 100%" class="p-button--neutral"
+                               href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-limenet.staging.snapcraft.io"
+                            >
+                                <small>Deploy to staging</small>
+                            </a>
+                        </td>
                     </tr>
                     <tr data-domain="maas.io">
                         <td><a href="https://staging.maas.io" target="_blank">staging.maas.io</a></td>
@@ -187,6 +205,13 @@
                         <td class="release">...</td>
                     </tr>
                     <tr data-domain="mir-server.io">
+                        <td><a href="https://staging.mir-server.io" target="_blank">staging.mir-server.io</a></td>
+                        <td class="image-tag">...</td>
+                        <td class="commit">...</td>
+                        <td class="human-time">...</td>
+                        <td class="release">...</td>
+                    </tr>
+                    <tr data-domain="multipass.run">
                         <td><a href="https://staging.mir-server.io" target="_blank">staging.mir-server.io</a></td>
                         <td class="image-tag">...</td>
                         <td class="commit">...</td>
@@ -218,9 +243,21 @@
                         <td><a href="https://tutorials.staging.ubuntu.com" target="_blank">tutorials.staging.ubuntu.com</a></td>
                         <td class="image-tag" colspan="4">not enabled - see <a href="https://wiki.canonical.com/ProductStrategyTeam/WebDevelopment/Websites">our wiki</a></td>
                     </tr>
-                    <tr>
-                        <td><a href="https://usn.staging.ubuntu.com" target="_blank">usn.staging.ubuntu.com</a></td>
-                        <td class="image-tag" colspan="4">not enabled - see <a href="https://wiki.canonical.com/ProductStrategyTeam/WebDevelopment/Websites">our wiki</a></td>
+                    <tr data-domain="usn.ubuntu.com">
+                        <td>
+                            <a href="https://usn.staging.ubuntu.com" target="_blank">usn.staging.ubuntu.com</a><br />
+                            <small>(not automatically updated)</small>
+                        </td>
+                        <td class="image-tag">...</td>
+                        <td class="commit">...</td>
+                        <td class="human-time">...</td>
+                        <td>
+                            <a style="width: 100%" class="p-button--neutral"
+                               href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-limenet.staging.snapcraft.io"
+                            >
+                                <small>Deploy to staging</small>
+                            </a>
+                        </td>
                     </tr>
                     <tr>
                         <td><a href="https://www.staging.canonical.com" target="_blank">www.staging.canonical.com</a></td>
@@ -238,7 +275,9 @@
             const domainRepositories = {
                 '360.canonical.com': 'canonical-web-and-design/360.canonical.com',
                 'blog.ubuntu.com': 'canonical-web-and-design/blog.ubuntu.com',
+                'cloud-init.io': 'canonical-web-and-design/cloud-init.io',
                 'cn.ubuntu.com': 'canonical-web-and-design/cn.ubuntu.com',
+                'conjure-up.io': 'canonical-web-and-design/conjure-up.io',
                 'design.ubuntu.com': 'canonical-web-and-design/design.ubuntu.com',
                 'developer.ubuntu.com': 'canonical-web-and-design/developer.ubuntu.com',
                 'docs.conjure-up.io': 'canonical-web-and-design/docs.conjure-up.io',
@@ -246,21 +285,17 @@
                 'docs.maas.io': 'CanonicalLtd/maas-docs',
                 'docs.snapcraft.io': 'canonical-web-and-design/docs.snapcraft.io',
                 'docs.ubuntu.com': 'canonical-web-and-design/docs.ubuntu.com',
-                'docs.vanillaframework.io': 'canonical-web-and-design/vanilla-framework',
                 'engage.canonical.com': 'canonical-web-and-design/engage.canonical.com-public-cloud',
-                'jp.ubuntu.com': 'canonical-web-and-design/jp.ubuntu.com',
-                'limenet.snapcraft.io': 'canonical-web-and-design/snapcraft.io',
-                'cloud-init.io': 'canonical-web-and-design/cloud-init.io',
-                'conjure-up.io': 'canonical-web-and-design/conjure-up.io',
                 'jaas.ai': 'canonical-web-and-design/jaas.ai',
-                'old-docs.jujucharms.com': 'juju/docs',
-                'sdrsatcom.snapcraft.io': 'canonical-web-and-design/snapcraft.io',
-                'tutorials.ubuntu.com': 'canonical-web-and-design/tutorials.ubuntu.com',
+                'jp.ubuntu.com': 'canonical-web-and-design/jp.ubuntu.com',
                 'maas.io': 'canonical-web-and-design/maas.io',
                 'microk8s.io': 'canonical-web-and-design/microk8s.io',
                 'mir-server.io': 'canonical-web-and-design/mir-server.io',
+                'multipass.run': 'canonical-web-and-design/multipass.run',
                 'netplan.io': 'canonical-web-and-design/netplan.io',
+                'old-docs.jujucharms.com': 'juju/docs',
                 'snapcraft.io': 'canonical-web-and-design/snapcraft.io',
+                'tutorials.ubuntu.com': 'canonical-web-and-design/tutorials.ubuntu.com',
                 'vanillaframework.io': 'canonical-web-and-design/vanillaframework.io'
             };
 
@@ -276,18 +311,18 @@
                         imageTag.innerHTML = `<small style="color: red; font-style: italic">${domainJson.error}</small>`;
                         commit.remove();
                         humanTime.remove();
-                        release.remove();
+                        if (release) {
+                            release.remove();
+                        }
                     } else {
                         imageTag.innerHTML = `<code>${domainJson['imageTag']}</code>`;
                         commit.innerHTML = `<a href="https://github.com/${domainRepositories[domainJson['domain']]}/commit/${domainJson['commitId']}">${domainJson['commitId']}</a>`;
                         humanTime.textContent = domainJson['humanTime'];
-                        release.innerHTML = `<a ` +
-                                            `  style="width: 100%" ` +
-                                            `  class="p-button--neutral" ` +
-                                            `  href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-${domainJson['domain']}%2Fparambuild%2F%3Fimage_tag%3D${domainJson['imageTag']}"` +
-                                            `>` +
-                                            `  Release` +
-                                            `</a>`;
+                        if (release) {
+                            release.innerHTML = `<a style="width: 100%" class="p-button--neutral" href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-${domainJson['domain']}%2Fparambuild%2F%3Fimage_tag%3D${domainJson['imageTag']}">` +
+                                                `  Release` +
+                                                `</a>`;
+                        }
                     }
                 }
             }

--- a/templates/index.html
+++ b/templates/index.html
@@ -96,12 +96,9 @@
                         <td class="human-time">...</td>
                         <td class="release">...</td>
                     </tr>
-                    <tr data-domain="docs.vanillaframework.io">
+                    <tr>
                         <td><a href="https://docs.staging.vanillaframework.io" target="_blank">docs.staging.vanillaframework.io</a></td>
-                        <td class="image-tag">...</td>
-                        <td class="commit">...</td>
-                        <td class="human-time">...</td>
-                        <td class="release">...</td>
+                        <td class="image-tag" colspan="4">Not enabled - see <a href="https://wiki.canonical.com/ProductStrategyTeam/WebDevelopment/Websites">the wiki</a></td>
                     </tr>
                     <tr data-domain="engage.canonical.com">
                         <td><a href="https://engage.staging.canonical.com" target="_blank">engage.staging.canonical.com</a></td>

--- a/templates/index.html
+++ b/templates/index.html
@@ -212,7 +212,7 @@
                         <td class="release">...</td>
                     </tr>
                     <tr data-domain="multipass.run">
-                        <td><a href="https://staging.mir-server.io" target="_blank">staging.mir-server.io</a></td>
+                        <td><a href="https://staging.multipass.run" target="_blank">staging.multipass.run</a></td>
                         <td class="image-tag">...</td>
                         <td class="commit">...</td>
                         <td class="human-time">...</td>

--- a/templates/index.html
+++ b/templates/index.html
@@ -33,6 +33,10 @@
                         <td class="human-time">...</td>
                         <td class="release">...</td>
                     </tr>
+                    <tr>
+                        <td><a href="https://assets.ubuntu.com" target="_blank">assets.ubuntu.com</a></td>
+                        <td class="image-tag" colspan="4">not enabled - see <a href="https://wiki.canonical.com/ProductStrategyTeam/WebDevelopment/Websites">our wiki</a></td>
+                    </tr>
                     <tr data-domain="blog.ubuntu.com">
                         <td><a href="https://blog.staging.ubuntu.com" target="_blank">blog.staging.ubuntu.com</a></td>
                         <td class="image-tag">...</td>
@@ -98,7 +102,7 @@
                     </tr>
                     <tr>
                         <td><a href="https://docs.staging.vanillaframework.io" target="_blank">docs.staging.vanillaframework.io</a></td>
-                        <td class="image-tag" colspan="4">Not enabled - see <a href="https://wiki.canonical.com/ProductStrategyTeam/WebDevelopment/Websites">the wiki</a></td>
+                        <td class="image-tag" colspan="4">not enabled - see <a href="https://wiki.canonical.com/ProductStrategyTeam/WebDevelopment/Websites">our wiki</a></td>
                     </tr>
                     <tr data-domain="engage.canonical.com">
                         <td><a href="https://engage.staging.canonical.com" target="_blank">engage.staging.canonical.com</a></td>
@@ -123,7 +127,11 @@
                     </tr>
                     <tr>
                         <td><a href="http://landscape-brochure.internal" target="_blank">landscape-brochure.internal</a></td>
-                        <td class="image-tag" colspan="4">Not enabled - see <a href="https://wiki.canonical.com/ProductStrategyTeam/WebDevelopment/Websites">the wiki</a></td>
+                        <td class="image-tag" colspan="4">not enabled - see <a href="https://wiki.canonical.com/ProductStrategyTeam/WebDevelopment/Websites">our wiki</a></td>
+                    </tr>
+                    <tr>
+                        <td><a href="https://manager.assets.ubuntu.com" target="_blank">manager.assets.ubuntu.com</a></td>
+                        <td class="image-tag" colspan="4">not enabled - see <a href="https://wiki.canonical.com/ProductStrategyTeam/WebDevelopment/Websites">our wiki</a></td>
                     </tr>
                     <tr data-domain="cloud-init.io">
                         <td><a href="https://staging.cloud-init.io" target="_blank">staging.cloud-init.io</a></td>
@@ -154,8 +162,8 @@
                         <td class="release">...</td>
                     </tr>
                     <tr>
-                        <td><a href="https://usn.staging.ubuntu.com" target="_blank">usn.staging.ubuntu.com</a></td>
-                        <td class="image-tag" colspan="4">Not enabled - see <a href="https://wiki.canonical.com/ProductStrategyTeam/WebDevelopment/Websites">the wiki</a></td>
+                        <td><a href="https://partners.staging.ubuntu.com" target="_blank">partners.staging.ubuntu.com</a></td>
+                        <td class="image-tag" colspan="4">not enabled - see <a href="https://wiki.canonical.com/ProductStrategyTeam/WebDevelopment/Websites">our wiki</a></td>
                     </tr>
                     <tr data-domain="sdrsatcom.snapcraft.io">
                         <td><a href="https://sdrsatcom.staging.snapcraft.io" target="_blank">sdrsatcom.staging.snapcraft.io</a></td>
@@ -163,10 +171,6 @@
                         <td class="commit">...</td>
                         <td class="human-time">...</td>
                         <td class="release">...</td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://tutorials.staging.ubuntu.com" target="_blank">tutorials.staging.ubuntu.com</a></td>
-                        <td class="image-tag" colspan="4">Not enabled - see <a href="https://wiki.canonical.com/ProductStrategyTeam/WebDevelopment/Websites">the wiki</a></td>
                     </tr>
                     <tr data-domain="maas.io">
                         <td><a href="https://staging.maas.io" target="_blank">staging.maas.io</a></td>
@@ -209,6 +213,22 @@
                         <td class="commit">...</td>
                         <td class="human-time">...</td>
                         <td class="release">...</td>
+                    </tr>
+                    <tr>
+                        <td><a href="https://tutorials.staging.ubuntu.com" target="_blank">tutorials.staging.ubuntu.com</a></td>
+                        <td class="image-tag" colspan="4">not enabled - see <a href="https://wiki.canonical.com/ProductStrategyTeam/WebDevelopment/Websites">our wiki</a></td>
+                    </tr>
+                    <tr>
+                        <td><a href="https://usn.staging.ubuntu.com" target="_blank">usn.staging.ubuntu.com</a></td>
+                        <td class="image-tag" colspan="4">not enabled - see <a href="https://wiki.canonical.com/ProductStrategyTeam/WebDevelopment/Websites">our wiki</a></td>
+                    </tr>
+                    <tr>
+                        <td><a href="https://www.staging.canonical.com" target="_blank">www.staging.canonical.com</a></td>
+                        <td class="image-tag" colspan="4">not enabled - see <a href="https://wiki.canonical.com/ProductStrategyTeam/WebDevelopment/Websites">our wiki</a></td>
+                    </tr>
+                    <tr>
+                        <td><a href="https://www.staging.ubuntu.com" target="_blank">www.staging.ubuntu.com</a></td>
+                        <td class="image-tag" colspan="4">not enabled - see <a href="https://wiki.canonical.com/ProductStrategyTeam/WebDevelopment/Websites">our wiki</a></td>
                     </tr>
                 </table>
             </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,222 +19,226 @@
         <div class="p-strip is-shallow is-bordered">
             <div class="row">
                 <table>
-                    <tr>
-                        <th width="250">Staging domain</th>
-                        <th width="170">Image tag</th>
-                        <th>Commit</th>
-                        <th width="230">Deployed to staging</th>
-                        <th width="100"></th>
-                    </tr>
-                    <tr data-domain="360.canonical.com">
-                        <td><a href="https://360.staging.canonical.com" target="_blank">360.staging.canonical.com</a></td>
-                        <td class="image-tag">...</td>
-                        <td class="commit">...</td>
-                        <td class="human-time">...</td>
-                        <td class="release">...</td>
-                    </tr>
-                    <tr data-domain="blog.ubuntu.com">
-                        <td><a href="https://blog.staging.ubuntu.com" target="_blank">blog.staging.ubuntu.com</a></td>
-                        <td class="image-tag">...</td>
-                        <td class="commit">...</td>
-                        <td class="human-time">...</td>
-                        <td class="release">...</td>
-                    </tr>
-                    <tr data-domain="cn.ubuntu.com">
-                        <td><a href="https://cn.staging.ubuntu.com" target="_blank">cn.staging.ubuntu.com</a></td>
-                        <td class="image-tag">...</td>
-                        <td class="commit">...</td>
-                        <td class="human-time">...</td>
-                        <td class="release">...</td>
-                    </tr>
-                    <tr data-domain="design.ubuntu.com">
-                        <td><a href="https://design.staging.ubuntu.com" target="_blank">design.staging.ubuntu.com</a></td>
-                        <td class="image-tag">...</td>
-                        <td class="commit">...</td>
-                        <td class="human-time">...</td>
-                        <td class="release">...</td>
-                    </tr>
-                    <tr data-domain="developer.ubuntu.com">
-                        <td><a href="https://developer.staging.ubuntu.com" target="_blank">developer.staging.ubuntu.com</a></td>
-                        <td class="image-tag">...</td>
-                        <td class="commit">...</td>
-                        <td class="human-time">...</td>
-                        <td class="release">...</td>
-                    </tr>
-                    <tr data-domain="docs.conjure-up.io">
-                        <td><a href="https://docs.staging.conjure-up.io" target="_blank">docs.staging.conjure-up.io</a></td>
-                        <td class="image-tag">...</td>
-                        <td class="commit">...</td>
-                        <td class="human-time">...</td>
-                        <td class="release">...</td>
-                    </tr>
-                    <tr data-domain="docs.jujucharms.com">
-                        <td><a href="https://docs.staging.jujucharms.com" target="_blank">docs.staging.jujucharms.com</a></td>
-                        <td class="image-tag">...</td>
-                        <td class="commit">...</td>
-                        <td class="human-time">...</td>
-                        <td class="release">...</td>
-                    </tr>
-                    <tr data-domain="docs.maas.io">
-                        <td><a href="https://docs.staging.maas.io" target="_blank">docs.staging.maas.io</a></td>
-                        <td class="image-tag">...</td>
-                        <td class="commit">...</td>
-                        <td class="human-time">...</td>
-                        <td class="release">...</td>
-                    </tr>
-                    <tr data-domain="docs.snapcraft.io">
-                        <td><a href="https://docs.staging.snapcraft.io" target="_blank">docs.staging.snapcraft.io</a></td>
-                        <td class="image-tag">...</td>
-                        <td class="commit">...</td>
-                        <td class="human-time">...</td>
-                        <td class="release">...</td>
-                    </tr>
-                    <tr data-domain="docs.ubuntu.com">
-                        <td><a href="https://docs.staging.ubuntu.com" target="_blank">docs.staging.ubuntu.com</a></td>
-                        <td class="image-tag">...</td>
-                        <td class="commit">...</td>
-                        <td class="human-time">...</td>
-                        <td class="release">...</td>
-                    </tr>
-                    <tr data-domain="docs.vanillaframework.io">
-                        <td>
-                            <a href="https://docs.staging.vanillaframework.io" target="_blank">docs.staging.vanillaframework.io</a><br />
-                            <small>(not automatically updated)</small>
-                        </td>
-                        <td class="image-tag">...</td>
-                        <td class="commit">...</td>
-                        <td class="human-time">...</td>
-                        <td>
-                            <a class="p-button--neutral"
-                                href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-docs.staging.vanillaframework.io"
-                            >
-                                <small>Deploy to staging</small>
-                            </a>
-                        </td>
-                    </tr>
-                    <tr data-domain="engage.canonical.com">
-                        <td><a href="https://engage.staging.canonical.com" target="_blank">engage.staging.canonical.com</a></td>
-                        <td class="image-tag">...</td>
-                        <td class="commit">...</td>
-                        <td class="human-time">...</td>
-                        <td class="release">...</td>
-                    </tr>
-                    <tr data-domain="jp.ubuntu.com">
-                        <td><a href="https://jp.staging.ubuntu.com" target="_blank">jp.staging.ubuntu.com</a></td>
-                        <td class="image-tag">...</td>
-                        <td class="commit">...</td>
-                        <td class="human-time">...</td>
-                        <td class="release">...</td>
-                    </tr>
-                    <tr data-domain="limenet.snapcraft.io">
-                        <td>
-                            <a href="https://limenet.staging.snapcraft.io" target="_blank">limenet.staging.snapcraft.io</a><br />
-                            <small>(not automatically updated)</small>
-                        </td>
-                        <td class="image-tag">...</td>
-                        <td class="commit">...</td>
-                        <td class="human-time">...</td>
-                        <td>
-                            <a class="p-button--neutral"
-                               href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-limenet.staging.snapcraft.io"
-                            >
-                                <small>Deploy to staging</small>
-                            </a>
-                        </td>
-                    </tr>
-                    <tr data-domain="cloud-init.io">
-                        <td><a href="https://staging.cloud-init.io" target="_blank">staging.cloud-init.io</a></td>
-                        <td class="image-tag">...</td>
-                        <td class="commit">...</td>
-                        <td class="human-time">...</td>
-                        <td class="release">...</td>
-                    </tr>
-                    <tr data-domain="conjure-up.io">
-                        <td><a href="https://staging.conjure-up.io" target="_blank">staging.conjure-up.io</a></td>
-                        <td class="image-tag">...</td>
-                        <td class="commit">...</td>
-                        <td class="human-time">...</td>
-                        <td class="release">...</td>
-                    </tr>
-                    <tr data-domain="jaas.ai">
-                        <td><a href="https://staging.jaas.ai" target="_blank">staging.jaas.ai</a></td>
-                        <td class="image-tag">...</td>
-                        <td class="commit">...</td>
-                        <td class="human-time">...</td>
-                        <td class="release">...</td>
-                    </tr>
-                    <tr data-domain="old-docs.jujucharms.com">
-                        <td><a href="https://old-docs.staging.jujucharms.com" target="_blank">old-docs.staging.jujucharms.com</a></td>
-                        <td class="image-tag">...</td>
-                        <td class="commit">...</td>
-                        <td class="human-time">...</td>
-                        <td class="release">...</td>
-                    </tr>
-                    <tr data-domain="sdrsatcom.snapcraft.io">
-                        <td>
-                            <a href="https://sdrsatcom.staging.snapcraft.io" target="_blank">sdrsatcom.staging.snapcraft.io</a><br />
-                            <small>(not automatically updated)</small>
-                        </td>
-                        <td class="image-tag">...</td>
-                        <td class="commit">...</td>
-                        <td class="human-time">...</td>
-                        <td>
-                            <a class="p-button--neutral"
-                               href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-sdrsatcom.staging.snapcraft.io"
-                            >
-                                <small>Deploy to staging</small>
-                            </a>
-                        </td>
-                    </tr>
-                    <tr data-domain="maas.io">
-                        <td><a href="https://staging.maas.io" target="_blank">staging.maas.io</a></td>
-                        <td class="image-tag">...</td>
-                        <td class="commit">...</td>
-                        <td class="human-time">...</td>
-                        <td class="release">...</td>
-                    </tr>
-                    <tr data-domain="microk8s.io">
-                        <td><a href="https://staging.microk8s.io" target="_blank">staging.microk8s.io</a></td>
-                        <td class="image-tag">...</td>
-                        <td class="commit">...</td>
-                        <td class="human-time">...</td>
-                        <td class="release">...</td>
-                    </tr>
-                    <tr data-domain="mir-server.io">
-                        <td><a href="https://staging.mir-server.io" target="_blank">staging.mir-server.io</a></td>
-                        <td class="image-tag">...</td>
-                        <td class="commit">...</td>
-                        <td class="human-time">...</td>
-                        <td class="release">...</td>
-                    </tr>
-                    <tr data-domain="multipass.run">
-                        <td><a href="https://staging.multipass.run" target="_blank">staging.multipass.run</a></td>
-                        <td class="image-tag">...</td>
-                        <td class="commit">...</td>
-                        <td class="human-time">...</td>
-                        <td class="release">...</td>
-                    </tr>
-                    <tr data-domain="netplan.io">
-                        <td><a href="https://staging.netplan.io" target="_blank">staging.netplan.io</a></td>
-                        <td class="image-tag">...</td>
-                        <td class="commit">...</td>
-                        <td class="human-time">...</td>
-                        <td class="release">...</td>
-                    </tr>
-                    <tr data-domain="snapcraft.io">
-                        <td><a href="https://staging.snapcraft.io" target="_blank">staging.snapcraft.io</a></td>
-                        <td class="image-tag">...</td>
-                        <td class="commit">...</td>
-                        <td class="human-time">...</td>
-                        <td class="release">...</td>
-                    </tr>
-                    <tr data-domain="vanillaframework.io">
-                        <td><a href="https://staging.vanillaframework.io" target="_blank">staging.vanillaframework.io</a></td>
-                        <td class="image-tag">...</td>
-                        <td class="commit">...</td>
-                        <td class="human-time">...</td>
-                        <td class="release">...</td>
-                    </tr>
+                    <thead>
+                        <tr>
+                            <th width="250">Staging domain</th>
+                            <th width="170">Image tag</th>
+                            <th>Commit</th>
+                            <th width="230">Deployed to staging</th>
+                            <th width="100"></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr data-domain="360.canonical.com">
+                            <td><a href="https://360.staging.canonical.com" target="_blank">360.staging.canonical.com</a></td>
+                            <td class="image-tag">...</td>
+                            <td class="commit">...</td>
+                            <td class="human-time">...</td>
+                            <td class="release">...</td>
+                        </tr>
+                        <tr data-domain="blog.ubuntu.com">
+                            <td><a href="https://blog.staging.ubuntu.com" target="_blank">blog.staging.ubuntu.com</a></td>
+                            <td class="image-tag">...</td>
+                            <td class="commit">...</td>
+                            <td class="human-time">...</td>
+                            <td class="release">...</td>
+                        </tr>
+                        <tr data-domain="cn.ubuntu.com">
+                            <td><a href="https://cn.staging.ubuntu.com" target="_blank">cn.staging.ubuntu.com</a></td>
+                            <td class="image-tag">...</td>
+                            <td class="commit">...</td>
+                            <td class="human-time">...</td>
+                            <td class="release">...</td>
+                        </tr>
+                        <tr data-domain="design.ubuntu.com">
+                            <td><a href="https://design.staging.ubuntu.com" target="_blank">design.staging.ubuntu.com</a></td>
+                            <td class="image-tag">...</td>
+                            <td class="commit">...</td>
+                            <td class="human-time">...</td>
+                            <td class="release">...</td>
+                        </tr>
+                        <tr data-domain="developer.ubuntu.com">
+                            <td><a href="https://developer.staging.ubuntu.com" target="_blank">developer.staging.ubuntu.com</a></td>
+                            <td class="image-tag">...</td>
+                            <td class="commit">...</td>
+                            <td class="human-time">...</td>
+                            <td class="release">...</td>
+                        </tr>
+                        <tr data-domain="docs.conjure-up.io">
+                            <td><a href="https://docs.staging.conjure-up.io" target="_blank">docs.staging.conjure-up.io</a></td>
+                            <td class="image-tag">...</td>
+                            <td class="commit">...</td>
+                            <td class="human-time">...</td>
+                            <td class="release">...</td>
+                        </tr>
+                        <tr data-domain="docs.jujucharms.com">
+                            <td><a href="https://docs.staging.jujucharms.com" target="_blank">docs.staging.jujucharms.com</a></td>
+                            <td class="image-tag">...</td>
+                            <td class="commit">...</td>
+                            <td class="human-time">...</td>
+                            <td class="release">...</td>
+                        </tr>
+                        <tr data-domain="docs.maas.io">
+                            <td><a href="https://docs.staging.maas.io" target="_blank">docs.staging.maas.io</a></td>
+                            <td class="image-tag">...</td>
+                            <td class="commit">...</td>
+                            <td class="human-time">...</td>
+                            <td class="release">...</td>
+                        </tr>
+                        <tr data-domain="docs.snapcraft.io">
+                            <td><a href="https://docs.staging.snapcraft.io" target="_blank">docs.staging.snapcraft.io</a></td>
+                            <td class="image-tag">...</td>
+                            <td class="commit">...</td>
+                            <td class="human-time">...</td>
+                            <td class="release">...</td>
+                        </tr>
+                        <tr data-domain="docs.ubuntu.com">
+                            <td><a href="https://docs.staging.ubuntu.com" target="_blank">docs.staging.ubuntu.com</a></td>
+                            <td class="image-tag">...</td>
+                            <td class="commit">...</td>
+                            <td class="human-time">...</td>
+                            <td class="release">...</td>
+                        </tr>
+                        <tr data-domain="docs.vanillaframework.io">
+                            <td>
+                                <a href="https://docs.staging.vanillaframework.io" target="_blank">docs.staging.vanillaframework.io</a><br />
+                                <small>(not automatically updated)</small>
+                            </td>
+                            <td class="image-tag">...</td>
+                            <td class="commit">...</td>
+                            <td class="human-time">...</td>
+                            <td>
+                                <a class="p-button--neutral"
+                                    href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-docs.staging.vanillaframework.io"
+                                >
+                                    <small>Deploy to staging</small>
+                                </a>
+                            </td>
+                        </tr>
+                        <tr data-domain="engage.canonical.com">
+                            <td><a href="https://engage.staging.canonical.com" target="_blank">engage.staging.canonical.com</a></td>
+                            <td class="image-tag">...</td>
+                            <td class="commit">...</td>
+                            <td class="human-time">...</td>
+                            <td class="release">...</td>
+                        </tr>
+                        <tr data-domain="jp.ubuntu.com">
+                            <td><a href="https://jp.staging.ubuntu.com" target="_blank">jp.staging.ubuntu.com</a></td>
+                            <td class="image-tag">...</td>
+                            <td class="commit">...</td>
+                            <td class="human-time">...</td>
+                            <td class="release">...</td>
+                        </tr>
+                        <tr data-domain="limenet.snapcraft.io">
+                            <td>
+                                <a href="https://limenet.staging.snapcraft.io" target="_blank">limenet.staging.snapcraft.io</a><br />
+                                <small>(not automatically updated)</small>
+                            </td>
+                            <td class="image-tag">...</td>
+                            <td class="commit">...</td>
+                            <td class="human-time">...</td>
+                            <td>
+                                <a class="p-button--neutral"
+                                href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-limenet.staging.snapcraft.io"
+                                >
+                                    <small>Deploy to staging</small>
+                                </a>
+                            </td>
+                        </tr>
+                        <tr data-domain="cloud-init.io">
+                            <td><a href="https://staging.cloud-init.io" target="_blank">staging.cloud-init.io</a></td>
+                            <td class="image-tag">...</td>
+                            <td class="commit">...</td>
+                            <td class="human-time">...</td>
+                            <td class="release">...</td>
+                        </tr>
+                        <tr data-domain="conjure-up.io">
+                            <td><a href="https://staging.conjure-up.io" target="_blank">staging.conjure-up.io</a></td>
+                            <td class="image-tag">...</td>
+                            <td class="commit">...</td>
+                            <td class="human-time">...</td>
+                            <td class="release">...</td>
+                        </tr>
+                        <tr data-domain="jaas.ai">
+                            <td><a href="https://staging.jaas.ai" target="_blank">staging.jaas.ai</a></td>
+                            <td class="image-tag">...</td>
+                            <td class="commit">...</td>
+                            <td class="human-time">...</td>
+                            <td class="release">...</td>
+                        </tr>
+                        <tr data-domain="old-docs.jujucharms.com">
+                            <td><a href="https://old-docs.staging.jujucharms.com" target="_blank">old-docs.staging.jujucharms.com</a></td>
+                            <td class="image-tag">...</td>
+                            <td class="commit">...</td>
+                            <td class="human-time">...</td>
+                            <td class="release">...</td>
+                        </tr>
+                        <tr data-domain="sdrsatcom.snapcraft.io">
+                            <td>
+                                <a href="https://sdrsatcom.staging.snapcraft.io" target="_blank">sdrsatcom.staging.snapcraft.io</a><br />
+                                <small>(not automatically updated)</small>
+                            </td>
+                            <td class="image-tag">...</td>
+                            <td class="commit">...</td>
+                            <td class="human-time">...</td>
+                            <td>
+                                <a class="p-button--neutral"
+                                href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-sdrsatcom.staging.snapcraft.io"
+                                >
+                                    <small>Deploy to staging</small>
+                                </a>
+                            </td>
+                        </tr>
+                        <tr data-domain="maas.io">
+                            <td><a href="https://staging.maas.io" target="_blank">staging.maas.io</a></td>
+                            <td class="image-tag">...</td>
+                            <td class="commit">...</td>
+                            <td class="human-time">...</td>
+                            <td class="release">...</td>
+                        </tr>
+                        <tr data-domain="microk8s.io">
+                            <td><a href="https://staging.microk8s.io" target="_blank">staging.microk8s.io</a></td>
+                            <td class="image-tag">...</td>
+                            <td class="commit">...</td>
+                            <td class="human-time">...</td>
+                            <td class="release">...</td>
+                        </tr>
+                        <tr data-domain="mir-server.io">
+                            <td><a href="https://staging.mir-server.io" target="_blank">staging.mir-server.io</a></td>
+                            <td class="image-tag">...</td>
+                            <td class="commit">...</td>
+                            <td class="human-time">...</td>
+                            <td class="release">...</td>
+                        </tr>
+                        <tr data-domain="multipass.run">
+                            <td><a href="https://staging.multipass.run" target="_blank">staging.multipass.run</a></td>
+                            <td class="image-tag">...</td>
+                            <td class="commit">...</td>
+                            <td class="human-time">...</td>
+                            <td class="release">...</td>
+                        </tr>
+                        <tr data-domain="netplan.io">
+                            <td><a href="https://staging.netplan.io" target="_blank">staging.netplan.io</a></td>
+                            <td class="image-tag">...</td>
+                            <td class="commit">...</td>
+                            <td class="human-time">...</td>
+                            <td class="release">...</td>
+                        </tr>
+                        <tr data-domain="snapcraft.io">
+                            <td><a href="https://staging.snapcraft.io" target="_blank">staging.snapcraft.io</a></td>
+                            <td class="image-tag">...</td>
+                            <td class="commit">...</td>
+                            <td class="human-time">...</td>
+                            <td class="release">...</td>
+                        </tr>
+                        <tr data-domain="vanillaframework.io">
+                            <td><a href="https://staging.vanillaframework.io" target="_blank">staging.vanillaframework.io</a></td>
+                            <td class="image-tag">...</td>
+                            <td class="commit">...</td>
+                            <td class="human-time">...</td>
+                            <td class="release">...</td>
+                        </tr>
+                    </tbody>
                 </table>
             </div>
         </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -106,7 +106,7 @@
                         <td class="human-time">...</td>
                         <td>
                             <a style="width: 100%" class="p-button--neutral"
-                                href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-limenet.staging.snapcraft.io"
+                                href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-docs.staging.vanillaframework.io"
                             >
                                 <small>Deploy to staging</small>
                             </a>
@@ -180,7 +180,7 @@
                         <td class="human-time">...</td>
                         <td>
                             <a style="width: 100%" class="p-button--neutral"
-                               href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-limenet.staging.snapcraft.io"
+                               href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-sdrsatcom.staging.snapcraft.io"
                             >
                                 <small>Deploy to staging</small>
                             </a>


### PR DESCRIPTION
docs.vanillaframework.io should only be released associated with a specific
published vanilla framework version tag, so it can't roll out to staging
automatically in the way our other sites do.

So we shouldn't have it enabled in this portal.

QA
--

Read the page