### PR TITLE
Alphabetical order; Add ubuntu.com

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -44,6 +44,20 @@
                             <td class="human-time">...</td>
                             <td class="release">...</td>
                         </tr>
+                        <tr data-domain="cloud-init.io">
+                            <td><a href="https://staging.cloud-init.io" target="_blank">staging.cloud-init.io</a></td>
+                            <td class="image-tag">...</td>
+                            <td class="commit">...</td>
+                            <td class="human-time">...</td>
+                            <td class="release">...</td>
+                        </tr>
+                        <tr data-domain="conjure-up.io">
+                            <td><a href="https://staging.conjure-up.io" target="_blank">staging.conjure-up.io</a></td>
+                            <td class="image-tag">...</td>
+                            <td class="commit">...</td>
+                            <td class="human-time">...</td>
+                            <td class="release">...</td>
+                        </tr>
                         <tr data-domain="cn.ubuntu.com">
                             <td><a href="https://cn.staging.ubuntu.com" target="_blank">cn.staging.ubuntu.com</a></td>
                             <td class="image-tag">...</td>
@@ -116,6 +130,13 @@
                             <td class="human-time">...</td>
                             <td class="release">...</td>
                         </tr>
+                        <tr data-domain="jaas.ai">
+                            <td><a href="https://staging.jaas.ai" target="_blank">staging.jaas.ai</a></td>
+                            <td class="image-tag">...</td>
+                            <td class="commit">...</td>
+                            <td class="human-time">...</td>
+                            <td class="release">...</td>
+                        </tr>
                         <tr data-domain="jp.ubuntu.com">
                             <td><a href="https://jp.staging.ubuntu.com" target="_blank">jp.staging.ubuntu.com</a></td>
                             <td class="image-tag">...</td>
@@ -134,50 +155,6 @@
                             <td>
                                 <a class="p-button--neutral"
                                 href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-limenet.staging.snapcraft.io"
-                                >
-                                    <small>Deploy to staging</small>
-                                </a>
-                            </td>
-                        </tr>
-                        <tr data-domain="cloud-init.io">
-                            <td><a href="https://staging.cloud-init.io" target="_blank">staging.cloud-init.io</a></td>
-                            <td class="image-tag">...</td>
-                            <td class="commit">...</td>
-                            <td class="human-time">...</td>
-                            <td class="release">...</td>
-                        </tr>
-                        <tr data-domain="conjure-up.io">
-                            <td><a href="https://staging.conjure-up.io" target="_blank">staging.conjure-up.io</a></td>
-                            <td class="image-tag">...</td>
-                            <td class="commit">...</td>
-                            <td class="human-time">...</td>
-                            <td class="release">...</td>
-                        </tr>
-                        <tr data-domain="jaas.ai">
-                            <td><a href="https://staging.jaas.ai" target="_blank">staging.jaas.ai</a></td>
-                            <td class="image-tag">...</td>
-                            <td class="commit">...</td>
-                            <td class="human-time">...</td>
-                            <td class="release">...</td>
-                        </tr>
-                        <tr data-domain="old-docs.jujucharms.com">
-                            <td><a href="https://old-docs.staging.jujucharms.com" target="_blank">old-docs.staging.jujucharms.com</a></td>
-                            <td class="image-tag">...</td>
-                            <td class="commit">...</td>
-                            <td class="human-time">...</td>
-                            <td class="release">...</td>
-                        </tr>
-                        <tr data-domain="sdrsatcom.snapcraft.io">
-                            <td>
-                                <a href="https://sdrsatcom.staging.snapcraft.io" target="_blank">sdrsatcom.staging.snapcraft.io</a><br />
-                                <small>(not automatically updated)</small>
-                            </td>
-                            <td class="image-tag">...</td>
-                            <td class="commit">...</td>
-                            <td class="human-time">...</td>
-                            <td>
-                                <a class="p-button--neutral"
-                                href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-sdrsatcom.staging.snapcraft.io"
                                 >
                                     <small>Deploy to staging</small>
                                 </a>
@@ -218,8 +195,38 @@
                             <td class="human-time">...</td>
                             <td class="release">...</td>
                         </tr>
+                        <tr data-domain="old-docs.jujucharms.com">
+                            <td><a href="https://old-docs.staging.jujucharms.com" target="_blank">old-docs.staging.jujucharms.com</a></td>
+                            <td class="image-tag">...</td>
+                            <td class="commit">...</td>
+                            <td class="human-time">...</td>
+                            <td class="release">...</td>
+                        </tr>
+                        <tr data-domain="sdrsatcom.snapcraft.io">
+                            <td>
+                                <a href="https://sdrsatcom.staging.snapcraft.io" target="_blank">sdrsatcom.staging.snapcraft.io</a><br />
+                                <small>(not automatically updated)</small>
+                            </td>
+                            <td class="image-tag">...</td>
+                            <td class="commit">...</td>
+                            <td class="human-time">...</td>
+                            <td>
+                                <a class="p-button--neutral"
+                                href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-sdrsatcom.staging.snapcraft.io"
+                                >
+                                    <small>Deploy to staging</small>
+                                </a>
+                            </td>
+                        </tr>
                         <tr data-domain="snapcraft.io">
                             <td><a href="https://staging.snapcraft.io" target="_blank">staging.snapcraft.io</a></td>
+                            <td class="image-tag">...</td>
+                            <td class="commit">...</td>
+                            <td class="human-time">...</td>
+                            <td class="release">...</td>
+                        </tr>
+                        <tr data-domain="ubuntu.com">
+                            <td><a href="https://staging.ubuntu.com" target="_blank">staging.ubuntu.com</a></td>
                             <td class="image-tag">...</td>
                             <td class="commit">...</td>
                             <td class="human-time">...</td>
@@ -263,7 +270,7 @@
                 'old-docs.jujucharms.com': 'juju/docs',
                 'snapcraft.io': 'canonical-web-and-design/snapcraft.io',
                 'sdrsatcom.snapcraft.io': 'canonical-web-and-design/snapcraft.io',
-                'tutorials.ubuntu.com': 'canonical-web-and-design/tutorials.ubuntu.com',
+                'ubuntu.com': 'canonical-web-and-design/ubuntu.com',
                 'vanillaframework.io': 'canonical-web-and-design/vanillaframework.io'
             };
 
@@ -316,7 +323,6 @@
                 <li><a href="https://tutorials.staging.ubuntu.com" target="_blank">tutorials.staging.ubuntu.com</a></li>
                 <li><a href="https://usn.staging.ubuntu.com" target="_blank">usn.staging.ubuntu.com</a></li>
                 <li><a href="https://www.staging.canonical.com" target="_blank">www.staging.canonical.com</a></li>
-                <li><a href="https://www.staging.ubuntu.com" target="_blank">www.staging.ubuntu.com</a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
Rejoice for https://ubuntu.com has been brought into the fold.

I've also listed the domains in alphabetical order
(hopefull aiding findability).

QA
--

`./run` - check the ubuntu.com row looks sane.