### PR TITLE
Add table sorting to the release table

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -3,337 +3,467 @@
 <html>
 
 <head>
-    <title>Deployment portal</title>
-    <link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-1.8.1.min.css" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Deployment portal</title>
+  <link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-2.0.1.min.css" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
 </head>
 
 <body>
-    <main class="p-content">
-        <div class="p-strip--image p-strip--light" style="background-image: url('https://assets.ubuntu.com/v1/06a0285e-image-background-paper.png');">
-            <div class="row">
-                <h1>Web & design team deployment portal</h1>
-                <p>A portal to help push releases from staging to production</p>
-            </div>
-        </div>
+  <main class="p-content">
+    <div class="p-strip--image p-strip--light" style="background-image: url('https://assets.ubuntu.com/v1/06a0285e-image-background-paper.png');">
+      <div class="row">
+        <h1>Web &amp; design team deployment portal</h1>
+        <p>A portal to help push releases from staging to production</p>
+      </div>
+    </div>
 
-        <div class="p-strip is-shallow is-bordered">
-            <div class="row" style="overflow: auto">
-                <table>
-                    <thead>
-                        <tr>
-                            <th width="250">Staging domain</th>
-                            <th width="170">Image tag</th>
-                            <th width="80">Commit</th>
-                            <th width="230">Deployed to staging</th>
-                            <th width="100"></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr data-domain="360.canonical.com">
-                            <td><a href="https://360.staging.canonical.com" target="_blank">360.staging.canonical.com</a></td>
-                            <td class="image-tag">...</td>
-                            <td class="commit">...</td>
-                            <td class="human-time">...</td>
-                            <td class="release">...</td>
-                        </tr>
-                        <tr data-domain="blog.ubuntu.com">
-                            <td><a href="https://blog.staging.ubuntu.com" target="_blank">blog.staging.ubuntu.com</a></td>
-                            <td class="image-tag">...</td>
-                            <td class="commit">...</td>
-                            <td class="human-time">...</td>
-                            <td class="release">...</td>
-                        </tr>
-                        <tr data-domain="canonical.com">
-                            <td><a href="https://staging.canonical.com" target="_blank">staging.canonical.com</a></td>
-                            <td class="image-tag">...</td>
-                            <td class="commit">...</td>
-                            <td class="human-time">...</td>
-                            <td class="release">...</td>
-                        </tr>
-                        <tr data-domain="cloud-init.io">
-                            <td><a href="https://staging.cloud-init.io" target="_blank">staging.cloud-init.io</a></td>
-                            <td class="image-tag">...</td>
-                            <td class="commit">...</td>
-                            <td class="human-time">...</td>
-                            <td class="release">...</td>
-                        </tr>
-                        <tr data-domain="conjure-up.io">
-                            <td><a href="https://staging.conjure-up.io" target="_blank">staging.conjure-up.io</a></td>
-                            <td class="image-tag">...</td>
-                            <td class="commit">...</td>
-                            <td class="human-time">...</td>
-                            <td class="release">...</td>
-                        </tr>
-                        <tr data-domain="cn.ubuntu.com">
-                            <td><a href="https://cn.staging.ubuntu.com" target="_blank">cn.staging.ubuntu.com</a></td>
-                            <td class="image-tag">...</td>
-                            <td class="commit">...</td>
-                            <td class="human-time">...</td>
-                            <td class="release">...</td>
-                        </tr>
-                        <tr data-domain="design.ubuntu.com">
-                            <td><a href="https://design.staging.ubuntu.com" target="_blank">design.staging.ubuntu.com</a></td>
-                            <td class="image-tag">...</td>
-                            <td class="commit">...</td>
-                            <td class="human-time">...</td>
-                            <td class="release">...</td>
-                        </tr>
-                        <tr data-domain="docs.conjure-up.io">
-                            <td><a href="https://docs.staging.conjure-up.io" target="_blank">docs.staging.conjure-up.io</a></td>
-                            <td class="image-tag">...</td>
-                            <td class="commit">...</td>
-                            <td class="human-time">...</td>
-                            <td class="release">...</td>
-                        </tr>
-                        <tr data-domain="docs.jujucharms.com">
-                            <td><a href="https://docs.staging.jujucharms.com" target="_blank">docs.staging.jujucharms.com</a></td>
-                            <td class="image-tag">...</td>
-                            <td class="commit">...</td>
-                            <td class="human-time">...</td>
-                            <td class="release">...</td>
-                        </tr>
-                        <tr data-domain="docs.maas.io">
-                            <td><a href="https://docs.staging.maas.io" target="_blank">docs.staging.maas.io</a></td>
-                            <td class="image-tag">...</td>
-                            <td class="commit">...</td>
-                            <td class="human-time">...</td>
-                            <td class="release">...</td>
-                        </tr>
-                        <tr data-domain="docs.snapcraft.io">
-                            <td><a href="https://docs.staging.snapcraft.io" target="_blank">docs.staging.snapcraft.io</a></td>
-                            <td class="image-tag">...</td>
-                            <td class="commit">...</td>
-                            <td class="human-time">...</td>
-                            <td class="release">...</td>
-                        </tr>
-                        <tr data-domain="docs.ubuntu.com">
-                            <td><a href="https://docs.staging.ubuntu.com" target="_blank">docs.staging.ubuntu.com</a></td>
-                            <td class="image-tag">...</td>
-                            <td class="commit">...</td>
-                            <td class="human-time">...</td>
-                            <td class="release">...</td>
-                        </tr>
-                        <tr data-domain="docs.vanillaframework.io">
-                            <td>
-                                <a href="https://docs.staging.vanillaframework.io" target="_blank">docs.staging.vanillaframework.io</a><br />
-                                <small>(not automatically updated)</small>
-                            </td>
-                            <td class="image-tag">...</td>
-                            <td class="commit">...</td>
-                            <td class="human-time">...</td>
-                            <td>
-                                <a class="p-button--neutral"
-                                    href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-docs.staging.vanillaframework.io"
-                                >
-                                    <small>Deploy to staging</small>
-                                </a>
-                            </td>
-                        </tr>
-                        <tr data-domain="engage.canonical.com">
-                            <td><a href="https://engage.staging.canonical.com" target="_blank">engage.staging.canonical.com</a></td>
-                            <td class="image-tag">...</td>
-                            <td class="commit">...</td>
-                            <td class="human-time">...</td>
-                            <td class="release">...</td>
-                        </tr>
-                        <tr data-domain="jaas.ai">
-                            <td><a href="https://staging.jaas.ai" target="_blank">staging.jaas.ai</a></td>
-                            <td class="image-tag">...</td>
-                            <td class="commit">...</td>
-                            <td class="human-time">...</td>
-                            <td class="release">...</td>
-                        </tr>
-                        <tr data-domain="jp.ubuntu.com">
-                            <td><a href="https://jp.staging.ubuntu.com" target="_blank">jp.staging.ubuntu.com</a></td>
-                            <td class="image-tag">...</td>
-                            <td class="commit">...</td>
-                            <td class="human-time">...</td>
-                            <td class="release">...</td>
-                        </tr>
-                        <tr data-domain="limenet.snapcraft.io">
-                            <td>
-                                <a href="https://limenet.staging.snapcraft.io" target="_blank">limenet.staging.snapcraft.io</a><br />
-                                <small>(not automatically updated)</small>
-                            </td>
-                            <td class="image-tag">...</td>
-                            <td class="commit">...</td>
-                            <td class="human-time">...</td>
-                            <td>
-                                <a class="p-button--neutral"
-                                href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-limenet.staging.snapcraft.io"
-                                >
-                                    <small>Deploy to staging</small>
-                                </a>
-                            </td>
-                        </tr>
-                        <tr data-domain="maas.io">
-                            <td><a href="https://staging.maas.io" target="_blank">staging.maas.io</a></td>
-                            <td class="image-tag">...</td>
-                            <td class="commit">...</td>
-                            <td class="human-time">...</td>
-                            <td class="release">...</td>
-                        </tr>
-                        <tr data-domain="microk8s.io">
-                            <td><a href="https://staging.microk8s.io" target="_blank">staging.microk8s.io</a></td>
-                            <td class="image-tag">...</td>
-                            <td class="commit">...</td>
-                            <td class="human-time">...</td>
-                            <td class="release">...</td>
-                        </tr>
-                        <tr data-domain="mir-server.io">
-                            <td><a href="https://staging.mir-server.io" target="_blank">staging.mir-server.io</a></td>
-                            <td class="image-tag">...</td>
-                            <td class="commit">...</td>
-                            <td class="human-time">...</td>
-                            <td class="release">...</td>
-                        </tr>
-                        <tr data-domain="multipass.run">
-                            <td><a href="https://staging.multipass.run" target="_blank">staging.multipass.run</a></td>
-                            <td class="image-tag">...</td>
-                            <td class="commit">...</td>
-                            <td class="human-time">...</td>
-                            <td class="release">...</td>
-                        </tr>
-                        <tr data-domain="netplan.io">
-                            <td><a href="https://staging.netplan.io" target="_blank">staging.netplan.io</a></td>
-                            <td class="image-tag">...</td>
-                            <td class="commit">...</td>
-                            <td class="human-time">...</td>
-                            <td class="release">...</td>
-                        </tr>
-                        <tr data-domain="old-docs.jujucharms.com">
-                            <td><a href="https://old-docs.staging.jujucharms.com" target="_blank">old-docs.staging.jujucharms.com</a></td>
-                            <td class="image-tag">...</td>
-                            <td class="commit">...</td>
-                            <td class="human-time">...</td>
-                            <td class="release">...</td>
-                        </tr>
-                        <tr data-domain="sdrsatcom.snapcraft.io">
-                            <td>
-                                <a href="https://sdrsatcom.staging.snapcraft.io" target="_blank">sdrsatcom.staging.snapcraft.io</a><br />
-                                <small>(not automatically updated)</small>
-                            </td>
-                            <td class="image-tag">...</td>
-                            <td class="commit">...</td>
-                            <td class="human-time">...</td>
-                            <td>
-                                <a class="p-button--neutral"
-                                href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-sdrsatcom.staging.snapcraft.io"
-                                >
-                                    <small>Deploy to staging</small>
-                                </a>
-                            </td>
-                        </tr>
-                        <tr data-domain="snapcraft.io">
-                            <td><a href="https://staging.snapcraft.io" target="_blank">staging.snapcraft.io</a></td>
-                            <td class="image-tag">...</td>
-                            <td class="commit">...</td>
-                            <td class="human-time">...</td>
-                            <td class="release">...</td>
-                        </tr>
-                        <tr data-domain="ubuntu.com">
-                            <td><a href="https://staging.ubuntu.com" target="_blank">staging.ubuntu.com</a></td>
-                            <td class="image-tag">...</td>
-                            <td class="commit">...</td>
-                            <td class="human-time">...</td>
-                            <td class="release">...</td>
-                        </tr>
-                        <tr data-domain="vanillaframework.io">
-                            <td><a href="https://staging.vanillaframework.io" target="_blank">staging.vanillaframework.io</a></td>
-                            <td class="image-tag">...</td>
-                            <td class="commit">...</td>
-                            <td class="human-time">...</td>
-                            <td class="release">...</td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-        </div>
+    <div class="p-strip is-shallow is-bordered">
+      <div class="row" style="overflow: auto">
+        <table class="p-table--sortable" role="grid">
+          <thead>
+            <tr>
+              <th width="250" role="columnheader" id="t-domain" aria-sort="none">Staging domain</th>
+              <th width="170" role="columnheader" id="t-tag" aria-sort="none">Image tag</th>
+              <th width="80" role="columnheader" id="t-commit" aria-sort="none">Commit</th>
+              <th width="230" role="columnheader" id="t-deployed" aria-sort="none">Deployed to staging</th>
+              <th width="100" id="t-release" aria-sort="none"></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr data-domain="360.canonical.com">
+              <td><a href="https://360.staging.canonical.com" target="_blank">360.staging.canonical.com</a></td>
+              <td class="image-tag">...</td>
+              <td class="commit">...</td>
+              <td class="human-time">...</td>
+              <td class="release">...</td>
+            </tr>
+            <tr data-domain="blog.ubuntu.com">
+              <td><a href="https://blog.staging.ubuntu.com" target="_blank">blog.staging.ubuntu.com</a></td>
+              <td class="image-tag">...</td>
+              <td class="commit">...</td>
+              <td class="human-time">...</td>
+              <td class="release">...</td>
+            </tr>
+            <tr data-domain="canonical.com">
+              <td><a href="https://staging.canonical.com" target="_blank">staging.canonical.com</a></td>
+              <td class="image-tag">...</td>
+              <td class="commit">...</td>
+              <td class="human-time">...</td>
+              <td class="release">...</td>
+            </tr>
+            <tr data-domain="cloud-init.io">
+              <td><a href="https://staging.cloud-init.io" target="_blank">staging.cloud-init.io</a></td>
+              <td class="image-tag">...</td>
+              <td class="commit">...</td>
+              <td class="human-time">...</td>
+              <td class="release">...</td>
+            </tr>
+            <tr data-domain="conjure-up.io">
+              <td><a href="https://staging.conjure-up.io" target="_blank">staging.conjure-up.io</a></td>
+              <td class="image-tag">...</td>
+              <td class="commit">...</td>
+              <td class="human-time">...</td>
+              <td class="release">...</td>
+            </tr>
+            <tr data-domain="cn.ubuntu.com">
+              <td><a href="https://cn.staging.ubuntu.com" target="_blank">cn.staging.ubuntu.com</a></td>
+              <td class="image-tag">...</td>
+              <td class="commit">...</td>
+              <td class="human-time">...</td>
+              <td class="release">...</td>
+            </tr>
+            <tr data-domain="design.ubuntu.com">
+              <td><a href="https://design.staging.ubuntu.com" target="_blank">design.staging.ubuntu.com</a></td>
+              <td class="image-tag">...</td>
+              <td class="commit">...</td>
+              <td class="human-time">...</td>
+              <td class="release">...</td>
+            </tr>
+            <tr data-domain="docs.conjure-up.io">
+              <td><a href="https://docs.staging.conjure-up.io" target="_blank">docs.staging.conjure-up.io</a></td>
+              <td class="image-tag">...</td>
+              <td class="commit">...</td>
+              <td class="human-time">...</td>
+              <td class="release">...</td>
+            </tr>
+            <tr data-domain="docs.jujucharms.com">
+              <td><a href="https://docs.staging.jujucharms.com" target="_blank">docs.staging.jujucharms.com</a></td>
+              <td class="image-tag">...</td>
+              <td class="commit">...</td>
+              <td class="human-time">...</td>
+              <td class="release">...</td>
+            </tr>
+            <tr data-domain="docs.maas.io">
+              <td><a href="https://docs.staging.maas.io" target="_blank">docs.staging.maas.io</a></td>
+              <td class="image-tag">...</td>
+              <td class="commit">...</td>
+              <td class="human-time">...</td>
+              <td class="release">...</td>
+            </tr>
+            <tr data-domain="docs.snapcraft.io">
+              <td><a href="https://docs.staging.snapcraft.io" target="_blank">docs.staging.snapcraft.io</a></td>
+              <td class="image-tag">...</td>
+              <td class="commit">...</td>
+              <td class="human-time">...</td>
+              <td class="release">...</td>
+            </tr>
+            <tr data-domain="docs.ubuntu.com">
+              <td><a href="https://docs.staging.ubuntu.com" target="_blank">docs.staging.ubuntu.com</a></td>
+              <td class="image-tag">...</td>
+              <td class="commit">...</td>
+              <td class="human-time">...</td>
+              <td class="release">...</td>
+            </tr>
+            <tr data-domain="docs.vanillaframework.io">
+              <td>
+                <a href="https://docs.staging.vanillaframework.io" target="_blank">docs.staging.vanillaframework.io</a><br />
+                <small>(not automatically updated)</small>
+              </td>
+              <td class="image-tag">...</td>
+              <td class="commit">...</td>
+              <td class="human-time">...</td>
+              <td>
+                <a class="p-button--neutral"
+                href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-docs.staging.vanillaframework.io"
+                >
+                  <small>Deploy to staging</small>
+                </a>
+              </td>
+            </tr>
+            <tr data-domain="engage.canonical.com">
+              <td><a href="https://engage.staging.canonical.com" target="_blank">engage.staging.canonical.com</a></td>
+              <td class="image-tag">...</td>
+              <td class="commit">...</td>
+              <td class="human-time">...</td>
+              <td class="release">...</td>
+            </tr>
+            <tr data-domain="jaas.ai">
+              <td><a href="https://staging.jaas.ai" target="_blank">staging.jaas.ai</a></td>
+              <td class="image-tag">...</td>
+              <td class="commit">...</td>
+              <td class="human-time">...</td>
+              <td class="release">...</td>
+            </tr>
+            <tr data-domain="jp.ubuntu.com">
+              <td><a href="https://jp.staging.ubuntu.com" target="_blank">jp.staging.ubuntu.com</a></td>
+              <td class="image-tag">...</td>
+              <td class="commit">...</td>
+              <td class="human-time">...</td>
+              <td class="release">...</td>
+            </tr>
+            <tr data-domain="limenet.snapcraft.io">
+              <td>
+                <a href="https://limenet.staging.snapcraft.io" target="_blank">limenet.staging.snapcraft.io</a><br />
+                <small>(not automatically updated)</small>
+              </td>
+              <td class="image-tag">...</td>
+              <td class="commit">...</td>
+              <td class="human-time">...</td>
+              <td>
+                <a class="p-button--neutral"
+                href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-limenet.staging.snapcraft.io"
+                >
+                  <small>Deploy to staging</small>
+                </a>
+              </td>
+            </tr>
+            <tr data-domain="maas.io">
+              <td><a href="https://staging.maas.io" target="_blank">staging.maas.io</a></td>
+              <td class="image-tag">...</td>
+              <td class="commit">...</td>
+              <td class="human-time">...</td>
+              <td class="release">...</td>
+            </tr>
+            <tr data-domain="microk8s.io">
+              <td><a href="https://staging.microk8s.io" target="_blank">staging.microk8s.io</a></td>
+              <td class="image-tag">...</td>
+              <td class="commit">...</td>
+              <td class="human-time">...</td>
+              <td class="release">...</td>
+            </tr>
+            <tr data-domain="mir-server.io">
+              <td><a href="https://staging.mir-server.io" target="_blank">staging.mir-server.io</a></td>
+              <td class="image-tag">...</td>
+              <td class="commit">...</td>
+              <td class="human-time">...</td>
+              <td class="release">...</td>
+            </tr>
+            <tr data-domain="multipass.run">
+              <td><a href="https://staging.multipass.run" target="_blank">staging.multipass.run</a></td>
+              <td class="image-tag">...</td>
+              <td class="commit">...</td>
+              <td class="human-time">...</td>
+              <td class="release">...</td>
+            </tr>
+            <tr data-domain="netplan.io">
+              <td><a href="https://staging.netplan.io" target="_blank">staging.netplan.io</a></td>
+              <td class="image-tag">...</td>
+              <td class="commit">...</td>
+              <td class="human-time">...</td>
+              <td class="release">...</td>
+            </tr>
+            <tr data-domain="old-docs.jujucharms.com">
+              <td><a href="https://old-docs.staging.jujucharms.com" target="_blank">old-docs.staging.jujucharms.com</a></td>
+              <td class="image-tag">...</td>
+              <td class="commit">...</td>
+              <td class="human-time">...</td>
+              <td class="release">...</td>
+            </tr>
+            <tr data-domain="sdrsatcom.snapcraft.io">
+              <td>
+                <a href="https://sdrsatcom.staging.snapcraft.io" target="_blank">sdrsatcom.staging.snapcraft.io</a><br />
+                <small>(not automatically updated)</small>
+              </td>
+              <td class="image-tag">...</td>
+              <td class="commit">...</td>
+              <td class="human-time">...</td>
+              <td>
+                <a class="p-button--neutral"
+                href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-sdrsatcom.staging.snapcraft.io"
+                >
+                <small>Deploy to staging</small>
+              </a>
+            </td>
+          </tr>
+          <tr data-domain="snapcraft.io">
+            <td><a href="https://staging.snapcraft.io" target="_blank">staging.snapcraft.io</a></td>
+            <td class="image-tag">...</td>
+            <td class="commit">...</td>
+            <td class="human-time">...</td>
+            <td class="release">...</td>
+          </tr>
+          <tr data-domain="ubuntu.com">
+            <td><a href="https://staging.ubuntu.com" target="_blank">staging.ubuntu.com</a></td>
+            <td class="image-tag">...</td>
+            <td class="commit">...</td>
+            <td class="human-time">...</td>
+            <td class="release">...</td>
+          </tr>
+          <tr data-domain="vanillaframework.io">
+            <td><a href="https://staging.vanillaframework.io" target="_blank">staging.vanillaframework.io</a></td>
+            <td class="image-tag">...</td>
+            <td class="commit">...</td>
+            <td class="human-time">...</td>
+            <td class="release">...</td>
+          </tr>
+        </tbody>
+      </table>
+  </div>
+</div>
 
-        <script>
-            const domainRepositories = {
-                '360.canonical.com': 'canonical-web-and-design/360.canonical.com',
-                'blog.ubuntu.com': 'canonical-web-and-design/blog.ubuntu.com',
-                'canonical.com': 'canonical-web-and-design/www.canonical.com',
-                'cloud-init.io': 'canonical-web-and-design/cloud-init.io',
-                'cn.ubuntu.com': 'canonical-web-and-design/cn.ubuntu.com',
-                'conjure-up.io': 'canonical-web-and-design/conjure-up.io',
-                'design.ubuntu.com': 'canonical-web-and-design/design.ubuntu.com',
-                'docs.conjure-up.io': 'canonical-web-and-design/docs.conjure-up.io',
-                'docs.jujucharms.com': 'canonical-web-and-design/docs.jujucharms.com',
-                'docs.maas.io': 'CanonicalLtd/maas-docs',
-                'docs.snapcraft.io': 'canonical-web-and-design/docs.snapcraft.io',
-                'docs.ubuntu.com': 'canonical-web-and-design/docs.ubuntu.com',
-                'docs.vanillaframework.io': 'canonical-web-and-design/vanilla-framework',
-                'engage.canonical.com': 'canonical-web-and-design/engage.canonical.com-public-cloud',
-                'jaas.ai': 'canonical-web-and-design/jaas.ai',
-                'jp.ubuntu.com': 'canonical-web-and-design/jp.ubuntu.com',
-                'limenet.snapcraft.io': 'canonical-web-and-design/snapcraft.io',
-                'maas.io': 'canonical-web-and-design/maas.io',
-                'microk8s.io': 'canonical-web-and-design/microk8s.io',
-                'mir-server.io': 'canonical-web-and-design/mir-server.io',
-                'multipass.run': 'canonical-web-and-design/multipass.run',
-                'netplan.io': 'canonical-web-and-design/netplan.io',
-                'old-docs.jujucharms.com': 'juju/docs',
-                'snapcraft.io': 'canonical-web-and-design/snapcraft.io',
-                'sdrsatcom.snapcraft.io': 'canonical-web-and-design/snapcraft.io',
-                'ubuntu.com': 'canonical-web-and-design/ubuntu.com',
-                'vanillaframework.io': 'canonical-web-and-design/vanillaframework.io'
-            };
+<script>
+  const domainRepositories = {
+    '360.canonical.com': 'canonical-web-and-design/360.canonical.com',
+    'blog.ubuntu.com': 'canonical-web-and-design/blog.ubuntu.com',
+    'canonical.com': 'canonical-web-and-design/www.canonical.com',
+    'cloud-init.io': 'canonical-web-and-design/cloud-init.io',
+    'cn.ubuntu.com': 'canonical-web-and-design/cn.ubuntu.com',
+    'conjure-up.io': 'canonical-web-and-design/conjure-up.io',
+    'design.ubuntu.com': 'canonical-web-and-design/design.ubuntu.com',
+    'docs.conjure-up.io': 'canonical-web-and-design/docs.conjure-up.io',
+    'docs.jujucharms.com': 'canonical-web-and-design/docs.jujucharms.com',
+    'docs.maas.io': 'CanonicalLtd/maas-docs',
+    'docs.snapcraft.io': 'canonical-web-and-design/docs.snapcraft.io',
+    'docs.ubuntu.com': 'canonical-web-and-design/docs.ubuntu.com',
+    'docs.vanillaframework.io': 'canonical-web-and-design/vanilla-framework',
+    'engage.canonical.com': 'canonical-web-and-design/engage.canonical.com-public-cloud',
+    'jaas.ai': 'canonical-web-and-design/jaas.ai',
+    'jp.ubuntu.com': 'canonical-web-and-design/jp.ubuntu.com',
+    'limenet.snapcraft.io': 'canonical-web-and-design/snapcraft.io',
+    'maas.io': 'canonical-web-and-design/maas.io',
+    'microk8s.io': 'canonical-web-and-design/microk8s.io',
+    'mir-server.io': 'canonical-web-and-design/mir-server.io',
+    'multipass.run': 'canonical-web-and-design/multipass.run',
+    'netplan.io': 'canonical-web-and-design/netplan.io',
+    'old-docs.jujucharms.com': 'juju/docs',
+    'snapcraft.io': 'canonical-web-and-design/snapcraft.io',
+    'sdrsatcom.snapcraft.io': 'canonical-web-and-design/snapcraft.io',
+    'ubuntu.com': 'canonical-web-and-design/ubuntu.com',
+    'vanillaframework.io': 'canonical-web-and-design/vanillaframework.io'
+  };
 
-            function writeDomainDetails(domainRow) {
-                return function (domainJson) {
-                    let imageTag = domainRow.querySelector('.image-tag');
-                    let commit = domainRow.querySelector('.commit');
-                    let humanTime = domainRow.querySelector('.human-time');
-                    let release = domainRow.querySelector('.release');
+  function writeDomainDetails(domainRow) {
+    return function (domainJson) {
+      let imageTag = domainRow.querySelector('.image-tag');
+      let commit = domainRow.querySelector('.commit');
+      let humanTime = domainRow.querySelector('.human-time');
+      let release = domainRow.querySelector('.release');
 
-                    if ('error' in domainJson) {
-                        imageTag.setAttribute('colspan', '3');
-                        imageTag.innerHTML = `<small style="color: red; font-style: italic">${domainJson.error}</small>`;
-                        commit.remove();
-                        humanTime.remove();
-                    } else {
-                        imageTag.innerHTML = `<code>${domainJson['imageTag']}</code>`;
-                        commit.innerHTML = `<a href="https://github.com/${domainRepositories[domainJson['domain']]}/commit/${domainJson['commitId']}">${domainJson['commitId']}</a>`;
-                        humanTime.textContent = domainJson['humanTime'];
-                        if (release) {
-                            release.innerHTML = `<a style="width: 100%" class="p-button--neutral" href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-${domainJson['domain']}%2Fparambuild%2F%3Fimage_tag%3D${domainJson['imageTag']}">` +
-                                                `  Release` +
-                                                `</a>`;
-                        }
-                    }
-                }
+      if ('error' in domainJson) {
+        imageTag.setAttribute('colspan', '3');
+        imageTag.innerHTML = `<small style="color: red; font-style: italic">${domainJson.error}</small>`;
+        commit.remove();
+        humanTime.remove();
+      } else {
+        imageTag.innerHTML = `<code>${domainJson['imageTag']}</code>`;
+        commit.innerHTML = `<a href="https://github.com/${domainRepositories[domainJson['domain']]}/commit/${domainJson['commitId']}">${domainJson['commitId']}</a>`;
+        humanTime.textContent = domainJson['humanTime'];
+        humanTime.dataset.sort = domainJson['epochTime'];
+        if (release) {
+          release.innerHTML = `<a style="width: 100%" class="p-button--neutral" href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-${domainJson['domain']}%2Fparambuild%2F%3Fimage_tag%3D${domainJson['imageTag']}">` +
+            `  Release` +
+            `</a>`;
+          }
+        }
+      }
+    }
+
+    document.querySelectorAll('[data-domain]').forEach(
+    function (domainRow) {
+      let domain = domainRow.dataset.domain;
+      fetch(`/domain-info.json?domain=${domain}`)
+      .then(async function (response) {
+        return response.json();
+      })
+      .then(writeDomainDetails(domainRow))
+    }
+    )
+  </script>
+
+  <script>
+    (function () {
+      /**
+      * Sort a table by the column specified.
+      *
+      * @param {HTMLTableElement} table
+      * @param {Number} col
+      */
+      function sortTable(table, col) {
+        // For readability set the scope to the header.
+        var header = this;
+        // Helper 'contant'.
+        var SORTABLE_STATES = {
+          none: 0,
+          ascending: -1,
+          descending: 1,
+          ORDER: ['none', 'ascending', 'descending']
+        };
+        // Based on the current aria-sort, get the next state.
+        var newOrder = SORTABLE_STATES.ORDER.indexOf(header.getAttribute('aria-sort')) + 1;
+        newOrder = newOrder > SORTABLE_STATES.ORDER.length - 1 ? 0 : newOrder;
+        newOrder = SORTABLE_STATES.ORDER[newOrder];
+        var currentSort = table.querySelectorAll('[aria-sort]');
+        // Reset all header sorts.
+        for (var i = 0, ii = currentSort.length; i < ii; i += 1) {
+          currentSort[i].setAttribute('aria-sort', 'none');
+        }
+        // Set the new header sort.
+        header.setAttribute('aria-sort', newOrder);
+        // Get the direction of the sort and assume only one tbody.
+        // For this example only assume one tbody.
+        var direction = SORTABLE_STATES[newOrder];
+        var body = table.tBodies[0];
+        // Convert the HTML element list to an array.
+        var newRows = Array.prototype.slice.call(body.rows, 0);
+        // If the direction is 0 - aria-sort="none".
+        if (direction === 0) {
+          // Reset to the default order.
+          newRows.sort(function (a, b) {
+            return a.getAttribute('data-index') - b.getAttribute('data-index');
+          });
+        } else {
+          newRows.sort(function (a, b) {
+            var c, d;
+            // Trim the cell contents.
+            if (a.cells[col].dataset.sort && b.cells[col].dataset.sort) {
+              c = a.cells[col].dataset.sort;
+              d = b.cells[col].dataset.sort;
+            } else {
+              c = a.cells[col].textContent.trim();
+              d = b.cells[col].textContent.trim();
             }
+            // If the content contains a number, parse it as a number.
+            // This is very crude and should not be considered production ready.
+            if (c.replace(/[^0-9]/gi, '') !== '' && !isNaN(c.replace(/[^0-9]/gi, ''))) {
+              c = parseInt(c.replace(/[^0-9]/gi, ''));
+              // Ascending for numbers and the alphabet are opposite.
+              direction *= -1;
+            }
+            if (d.replace(/[^0-9]/gi, '') !== '' && !isNaN(d.replace(/[^0-9]/gi, ''))) {
+              d = parseInt(d.replace(/[^0-9]/gi, ''));
+              // Ascending for numbers and the alphabet are opposite.
+              direction *= -1;
+            }
+            // Based on the direction, do the sort.
+            if (direction === 1) {
+              return c < d;
+            } else {
+              return c > d;
+            }
+          });
+        }
+        // Append each row into the table, replacing the current elements.
+        for (var i = 0, ii = body.rows.length; i < ii; i += 1) {
+          body.appendChild(newRows[i]);
+        }
+      }
+      /**
+      * Create a sortable table from a table.
+      * @param {HTMLTableElement} table
+      */
+      function createSortableTable(table) {
+        // Select sortable column headers.
+        var clickableHeaders = table.querySelectorAll('[role="columnheader"][aria-sort]');
+        // For this example, assume only one tbody.
+        var rows = table.tBodies[0].rows;
+        // Set an index for the default order.
+        for (var row = 0, totalRows = rows.length; row < totalRows; row += 1) {
+          rows[row].setAttribute('data-index', row);
+        }
+        // Attach the click event for each header.
+        for (var i = 0, ii = clickableHeaders.length; i < ii; i += 1) {
+          // Ensure we bind the event to the header and pass the table and column.
+          clickableHeaders[i].addEventListener('click', sortTable.bind(clickableHeaders[i], table, i));
+        }
+      }
+      /**
+      * Make all --sortable tables on the page sortable.
+      */
+      function createSortableTables() {
+        var tables = document.querySelectorAll('table.p-table--sortable');
+        for (var i = 0, ii = tables.length; i < ii; i += 1) {
+          createSortableTable(tables[i]);
+        }
+      }
+      createSortableTables();
+    })()
+  </script>
 
-            document.querySelectorAll('[data-domain]').forEach(
-                function (domainRow) {
-                    let domain = domainRow.dataset.domain;
-                    fetch(`/domain-info.json?domain=${domain}`)
-                        .then(async function (response) {
-                            return response.json();
-                        })
-                        .then(writeDomainDetails(domainRow))
-                }
-            )
-        </script>
-
-        <div class="p-strip is-shallow is-bordered">
-          <div class="row">
-            <h3>Staging domains not yet supported</h3>
-
-            <ul>
-                <li><a href="https://assets.staging.ubuntu.com" target="_blank">assets.staging.ubuntu.com</a></li>
-                <li><a href="http://landscape-brochure.staging.internal" target="_blank">landscape-brochure.staging.internal</a></li>
-                <li><a href="https://manager.assets.staging.ubuntu.com" target="_blank">manager.assets.staging.ubuntu.com</a></li>
-                <li><a href="https://partners.staging.ubuntu.com" target="_blank">partners.staging.ubuntu.com</a></li>
-                <li><a href="https://tutorials.staging.ubuntu.com" target="_blank">tutorials.staging.ubuntu.com</a></li>
-                <li><a href="https://usn.staging.ubuntu.com" target="_blank">usn.staging.ubuntu.com</a></li>
-            </ul>
-          </div>
-        </div>
-    </main>
+  <div class="p-strip--light">
+    <div class="row">
+      <h3>Staging domains not yet supported</h3>
+      <ul>
+        <li><a href="https://assets.staging.ubuntu.com" target="_blank">assets.staging.ubuntu.com</a></li>
+        <li><a href="http://landscape-brochure.staging.internal" target="_blank">landscape-brochure.staging.internal</a></li>
+        <li><a href="https://manager.assets.staging.ubuntu.com" target="_blank">manager.assets.staging.ubuntu.com</a></li>
+        <li><a href="https://partners.staging.ubuntu.com" target="_blank">partners.staging.ubuntu.com</a></li>
+        <li><a href="https://tutorials.staging.ubuntu.com" target="_blank">tutorials.staging.ubuntu.com</a></li>
+        <li><a href="https://usn.staging.ubuntu.com" target="_blank">usn.staging.ubuntu.com</a></li>
+      </ul>
+    </div>
+  </div>
+  <hr />
+  <footer class="p-strip is-shallow">
+    <div class="row">
+      <div class="col-12">
+        © 2019 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.
+        <nav>
+          <ul class="p-inline-list--middot">
+            <li class="p-inline-list__item">
+              <a href="https://www.ubuntu.com/legal">Legal info</a>
+            </li>
+            <li class="p-inline-list__item">
+              <a href="https://github.com/canonical-web-and-design/releases.demo.haus/issues/new">Report a bug with this site</a>
+            </li>
+          </ul>
+          <span class="u-off-screen">
+            <a href="#">Go to the top of the page</a>
+          </span>
+        </nav>
+      </div>
+    </div>
+  </footer>
+</main>
 </body>
 
 </html>


### PR DESCRIPTION
## Done
- Upgraded to Vanilla 2.0.1
- Add the Vanilla sortable pattern to the table

## QA
- Wait for the deployed to staging to populate
- Then sort by clicking the table heading
- Check its in the correct order

Fixes https://github.com/canonical-web-and-design/releases.demo.haus/issues/12