### PR TITLE
 Replace release button if up to date 

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle",
     "serve": "./entrypoint 0.0.0.0:$PORT",
     "build": "echo 'nothing to build'",
+    "format-python": "black --line-length 79 webapp",
     "lint-python": "flake8 webapp && black --check --line-length 79 webapp",
     "test": "yarn run lint-python"
   }

--- a/templates/index.html
+++ b/templates/index.html
@@ -308,7 +308,7 @@
                                   `  Release 🚀` +
                                   `</a>`;
             } else {
-              release.innerHTML = '<a style="width: 100%" class="p-button--neutral" href="#" disable="disable">Up to date 👍</a>';
+              release.innerHTML = '<button style="width: 100%" class="p-button--neutral" disabled="true">Up to date 👍</button>';
             }
           }
       }

--- a/templates/index.html
+++ b/templates/index.html
@@ -38,13 +38,6 @@
               <td class="human-time">...</td>
               <td class="release">...</td>
             </tr>
-            <tr data-domain="blog.ubuntu.com">
-              <td><a href="https://blog.staging.ubuntu.com" target="_blank">blog.staging.ubuntu.com</a></td>
-              <td class="image-tag">...</td>
-              <td class="commit">...</td>
-              <td class="human-time">...</td>
-              <td class="release">...</td>
-            </tr>
             <tr data-domain="canonical.com">
               <td><a href="https://staging.canonical.com" target="_blank">staging.canonical.com</a></td>
               <td class="image-tag">...</td>
@@ -255,7 +248,6 @@
 <script>
   const domainRepositories = {
     '360.canonical.com': 'canonical-web-and-design/360.canonical.com',
-    'blog.ubuntu.com': 'canonical-web-and-design/blog.ubuntu.com',
     'canonical.com': 'canonical-web-and-design/www.canonical.com',
     'cloud-init.io': 'canonical-web-and-design/cloud-init.io',
     'cn.ubuntu.com': 'canonical-web-and-design/cn.ubuntu.com',

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,7 +27,7 @@
               <th width="170" role="columnheader" id="t-tag" aria-sort="none">Image tag</th>
               <th width="80" role="columnheader" id="t-commit" aria-sort="none">Commit</th>
               <th width="230" role="columnheader" id="t-deployed" aria-sort="none">Deployed to staging</th>
-              <th width="100" id="t-release" aria-sort="none"></th>
+              <th width="125" id="t-release" aria-sort="none"></th>
             </tr>
           </thead>
           <tbody>
@@ -124,10 +124,10 @@
               <td class="commit">...</td>
               <td class="human-time">...</td>
               <td>
-                <a class="p-button--neutral"
+                <a class="p-button--neutral" style="width: 100%"
                 href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdocs.vanillaframework.io-staging%2Fbuild"
                 >
-                  <small>Deploy to staging</small>
+                  Deploy to staging
                 </a>
               </td>
             </tr>
@@ -161,10 +161,10 @@
               <td class="commit">...</td>
               <td class="human-time">...</td>
               <td>
-                <a class="p-button--neutral"
+                <a class="p-button--neutral" style="width: 100%"
                 href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Flimenet.snapcraft.io-staging%2Fbuild"
                 >
-                  <small>Deploy to staging</small>
+                  Deploy to staging
                 </a>
               </td>
             </tr>
@@ -219,10 +219,10 @@
               <td class="commit">...</td>
               <td class="human-time">...</td>
               <td>
-                <a class="p-button--neutral"
+                <a class="p-button--neutral" style="width: 100%"
                 href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fsdrsatcom.snapcraft.io-staging%2Fbuild"
                 >
-                <small>Deploy to staging</small>
+                Deploy to staging
               </a>
             </td>
           </tr>
@@ -299,7 +299,7 @@
           let stagingCommitID = domainJson['staging']['commitId'];
           let productionCommitID = domainJson['production']['commitId'];
           imageTag.innerHTML = `<code>${domainJson['staging']['imageTag']}</code>`;
-          commit.innerHTML = `<a href="https://github.com/${domainRepositories[domainJson['staging']['domain']]}/commit/${stagingCommitID}">${stagingCommitID}</a>`;
+          commit.innerHTML = `<a  href="https://github.com/${domainRepositories[domainJson['staging']['domain']]}/commit/${stagingCommitID}">${stagingCommitID}</a>`;
           humanTime.textContent = domainJson['staging']['humanTime'];
         humanTime.dataset.sort = domainJson['staging']['epochTime'];
           if (release) {
@@ -370,30 +370,34 @@
           newRows.sort(function (a, b) {
             var c, d;
             // Trim the cell contents.
-            if (a.cells[col].dataset.sort && b.cells[col].dataset.sort) {
-              c = a.cells[col].dataset.sort;
-              d = b.cells[col].dataset.sort;
+            if (a.cells[col] && b.cells[col]) {
+              if (a.cells[col].dataset.sort && b.cells[col].dataset.sort) {
+                c = a.cells[col].dataset.sort;
+                d = b.cells[col].dataset.sort;
+              } else {
+                c = a.cells[col].textContent.trim();
+                d = b.cells[col].textContent.trim();
+              }
+              // If the content contains a number, parse it as a number.
+              // This is very crude and should not be considered production ready.
+              if (c.replace(/[^0-9]/gi, '') !== '' && !isNaN(c.replace(/[^0-9]/gi, ''))) {
+                c = parseInt(c.replace(/[^0-9]/gi, ''));
+                // Ascending for numbers and the alphabet are opposite.
+                direction *= -1;
+              }
+              if (d.replace(/[^0-9]/gi, '') !== '' && !isNaN(d.replace(/[^0-9]/gi, ''))) {
+                d = parseInt(d.replace(/[^0-9]/gi, ''));
+                // Ascending for numbers and the alphabet are opposite.
+                direction *= -1;
+              }
+              // Based on the direction, do the sort.
+              if (direction === 1) {
+                return c < d;
+              } else {
+                return c > d;
+              }
             } else {
-              c = a.cells[col].textContent.trim();
-              d = b.cells[col].textContent.trim();
-            }
-            // If the content contains a number, parse it as a number.
-            // This is very crude and should not be considered production ready.
-            if (c.replace(/[^0-9]/gi, '') !== '' && !isNaN(c.replace(/[^0-9]/gi, ''))) {
-              c = parseInt(c.replace(/[^0-9]/gi, ''));
-              // Ascending for numbers and the alphabet are opposite.
-              direction *= -1;
-            }
-            if (d.replace(/[^0-9]/gi, '') !== '' && !isNaN(d.replace(/[^0-9]/gi, ''))) {
-              d = parseInt(d.replace(/[^0-9]/gi, ''));
-              // Ascending for numbers and the alphabet are opposite.
-              direction *= -1;
-            }
-            // Based on the direction, do the sort.
-            if (direction === 1) {
               return c < d;
-            } else {
-              return c > d;
             }
           });
         }

--- a/templates/index.html
+++ b/templates/index.html
@@ -290,34 +290,38 @@
       let release = domainRow.querySelector('.release');
 
       if ('error' in domainJson) {
-        imageTag.setAttribute('colspan', '3');
-        imageTag.innerHTML = `<small style="color: red; font-style: italic">${domainJson.error}</small>`;
-        commit.remove();
-        humanTime.remove();
+          imageTag.setAttribute('colspan', '3');
+          imageTag.innerHTML = `<small style="color: red; font-style: italic">${domainJson.error}</small>`;
+          commit.remove();
+          humanTime.remove();
       } else {
-        imageTag.innerHTML = `<code>${domainJson['imageTag']}</code>`;
-        commit.innerHTML = `<a href="https://github.com/${domainRepositories[domainJson['domain']]}/commit/${domainJson['commitId']}">${domainJson['commitId']}</a>`;
-        humanTime.textContent = domainJson['humanTime'];
-        humanTime.dataset.sort = domainJson['epochTime'];
-        if (release) {
-          release.innerHTML = `<a style="width: 100%" class="p-button--neutral" href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2F${domainJson['domain']}-production%2Fparambuild%2F%3Fimage_tag%3D${domainJson['imageTag']}">` +
-            `  Release` +
-            `</a>`;
+          let stagingCommitID = domainJson['staging']['commitId'];
+          let productionCommitID = domainJson['production']['commitId'];
+          imageTag.innerHTML = `<code>${domainJson['staging']['imageTag']}</code>`;
+          commit.innerHTML = `<a href="https://github.com/${domainRepositories[domainJson['staging']['domain']]}/commit/${stagingCommitID}">${stagingCommitID}</a>`;
+          humanTime.textContent = domainJson['staging']['humanTime'];
+        humanTime.dataset.sort = domainJson['staging']['epochTime'];
+          if (release) {
+            if (stagingCommitID !== productionCommitID) {
+              release.innerHTML = `<a style="width: 100%" class="p-button--neutral" href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-${domainJson['staging']['domain']}%2Fparambuild%2F%3Fimage_tag%3D${domainJson['staging']['imageTag']}">` +
+                                  `  Release` +
+                                  `</a>`;
+            } else {
+              release.innerHTML = "Up to date";
+            }
           }
-        }
       }
     }
+  }
 
-    document.querySelectorAll('[data-domain]').forEach(
-    function (domainRow) {
-      let domain = domainRow.dataset.domain;
-      fetch(`/domain-info.json?domain=${domain}`)
-      .then(async function (response) {
-        return response.json();
-      })
-      .then(writeDomainDetails(domainRow))
-    }
-    )
+  document.querySelectorAll('[data-domain]').forEach(function (domainRow) {
+    let domain = domainRow.dataset.domain;
+    fetch(`/domain-info.json?domain=${domain}`)
+    .then(async function (response) {
+      return response.json();
+    })
+    .then(writeDomainDetails(domainRow))
+  });
   </script>
 
   <script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,9 +3,10 @@
 <html>
 
 <head>
-  <title>Deployment portal</title>
+  <title>🚀 Deployment portal</title>
   <link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-2.0.1.min.css" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="shortcut icon" href="https://assets.ubuntu.com/v1/0843d517-favicon.ico" type="image/x-icon" />
 </head>
 
 <body>
@@ -304,10 +305,10 @@
           if (release) {
             if (stagingCommitID !== productionCommitID) {
               release.innerHTML = `<a style="width: 100%" class="p-button--neutral" href="https://jenkins.canonical.com/webteam/securityRealm/commenceLogin?from=%2Fwebteam%2Fjob%2Fdeploy-to-${domainJson['staging']['domain']}%2Fparambuild%2F%3Fimage_tag%3D${domainJson['staging']['imageTag']}">` +
-                                  `  Release` +
+                                  `  Release 🚀` +
                                   `</a>`;
             } else {
-              release.innerHTML = "Up to date";
+              release.innerHTML = '<a style="width: 100%" class="p-button--neutral" href="#" disable="disable">Up to date 👍</a>';
             }
           }
       }

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -17,52 +17,90 @@ def index():
 
 @app.route("/domain-info.json")
 def domain_info():
-    domain = flask.request.args["domain"]
-    staging_domain_parts = domain.split(".")
+    production_domain = flask.request.args["domain"]
+    staging_domain_parts = production_domain.split(".")
     staging_domain_parts.insert(-2, "staging")
     staging_domain = ".".join(staging_domain_parts)
 
-    response = requests.get(f"https://{staging_domain}/_status/check")
+    staging_response = requests.get(f"https://{staging_domain}/_status/check")
+    response = requests.get(f"https://{production_domain}/_status/check")
 
-    image_tag = response.headers.get("x-vcs-revision")
+    staging_image_tag = staging_response.headers.get("x-vcs-revision")
+    production_image_tag = response.headers.get("x-vcs-revision")
 
-    if not image_tag:
-        return (
-            json.dumps(
-                {"error": f"Couldn't find image tag for {staging_domain}"}
-            ),
-            402,
-            {"Content-Type": "application/json"},
-        )
+    if not staging_image_tag or not production_image_tag:
+        if not staging_image_tag:
+            return (
+                json.dumps(
+                    {
+                        "error": f"Couldn't find image tag "
+                        "for {staging_domain}"
+                    }
+                ),
+                402,
+                {"Content-Type": "application/json"},
+            )
+        else:
+            return (
+                json.dumps(
+                    {
+                        "error": f"Couldn't find image tag"
+                        " for {production_domain}"
+                    }
+                ),
+                402,
+                {"Content-Type": "application/json"},
+            )
 
-    match = re.match(r"(\d{10})-([\da-f]{7})", image_tag)
+    staging_match = re.match(r"(\d{10})-([\da-f]{7})", staging_image_tag)
+    production_match = re.match(r"(\d{10})-([\da-f]{7})", production_image_tag)
 
-    if not match:
-        return (
-            json.dumps(
-                {
-                    "error": f"Image tag '{image_tag}' for {staging_domain}"
-                    " in unexpected format"
-                }
-            ),
-            402,
-            {"Content-Type": "application/json"},
-        )
+    if not staging_match or not production_match:
+        if not staging_match:
+            return (
+                json.dumps(
+                    {
+                        "error": f"Image tag '{staging_image_tag}'"
+                        " for {staging_domain} in unexpected format"
+                    }
+                ),
+                402,
+                {"Content-Type": "application/json"},
+            )
+        else:
+            return (
+                json.dumps(
+                    {
+                        "error": f"Image tag '{production_image_tag}'"
+                        " for {production_domain} in unexpected format"
+                    }
+                ),
+                402,
+                {"Content-Type": "application/json"},
+            )
+    staging = {
+        "domain": staging_domain,
+        "imageTag": staging_image_tag,
+        "epochTime": int(staging_match.group(1)),
+        "commitId": staging_match.group(2),
+        "humanTime": datetime.datetime.fromtimestamp(
+            int(staging_match.group(1))).strftime("%c %Z")
+    }
 
-    epoch_time = int(match.group(1))
-    commit_id = match.group(2)
-
-    human_time = datetime.datetime.fromtimestamp(epoch_time).strftime("%c %Z")
+    production = {
+        "domain": production_domain,
+        "imageTag": production_image_tag,
+        "epochTime": int(production_match.group(1)),
+        "commitId": production_match.group(2),
+        "humanTime": datetime.datetime.fromtimestamp(
+            int(production_match.group(1))).strftime("%c %Z")
+    }
 
     return (
         json.dumps(
             {
-                "domain": domain,
-                "stagingDomain": staging_domain,
-                "imageTag": image_tag,
-                "epochTime": epoch_time,
-                "humanTime": human_time,
-                "commitId": commit_id,
+                "staging": staging,
+                "production": production,
             }
         ),
         200,

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -84,7 +84,8 @@ def domain_info():
         "epochTime": int(staging_match.group(1)),
         "commitId": staging_match.group(2),
         "humanTime": datetime.datetime.fromtimestamp(
-            int(staging_match.group(1))).strftime("%c %Z")
+            int(staging_match.group(1))
+        ).strftime("%c %Z"),
     }
 
     production = {
@@ -93,16 +94,12 @@ def domain_info():
         "epochTime": int(production_match.group(1)),
         "commitId": production_match.group(2),
         "humanTime": datetime.datetime.fromtimestamp(
-            int(production_match.group(1))).strftime("%c %Z")
+            int(production_match.group(1))
+        ).strftime("%c %Z"),
     }
 
     return (
-        json.dumps(
-            {
-                "staging": staging,
-                "production": production,
-            }
-        ),
+        json.dumps({"staging": staging, "production": production}),
         200,
         {"Content-Type": "application/json"},
     )

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -34,7 +34,7 @@ def domain_info():
                 json.dumps(
                     {
                         "error": f"Couldn't find image tag "
-                        "for {staging_domain}"
+                        "for %s" % (staging_domain)
                     }
                 ),
                 402,
@@ -45,7 +45,7 @@ def domain_info():
                 json.dumps(
                     {
                         "error": f"Couldn't find image tag"
-                        " for {production_domain}"
+                        " for %s" % (production_domain)
                     }
                 ),
                 402,
@@ -61,7 +61,7 @@ def domain_info():
                 json.dumps(
                     {
                         "error": f"Image tag '{staging_image_tag}'"
-                        " for {staging_domain} in unexpected format"
+                        " for %s in unexpected format" % (staging_domain)
                     }
                 ),
                 402,
@@ -72,7 +72,7 @@ def domain_info():
                 json.dumps(
                     {
                         "error": f"Image tag '{production_image_tag}'"
-                        " for {production_domain} in unexpected format"
+                        " for %s in unexpected format" % (production_domain)
                     }
                 ),
                 402,


### PR DESCRIPTION
## Done
Pass production information to the template and conditionally display the release button based on the commit ids. Added format-python npm script to aid linting.

## QA
- Run the site
- Go to http://0.0.0.0:8103/
- Check that some sites have "Up to date" where the release button used to be

FIxes https://github.com/canonical-web-and-design/releases.demo.haus/issues/15