### PR TITLE
Remove docs.{maas.io,snapcraft.io,jujucharms.com}

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -80,27 +80,6 @@
               <td class="human-time">...</td>
               <td class="release">...</td>
             </tr>
-            <tr data-domain="docs.jujucharms.com">
-              <td><a href="https://docs.staging.jujucharms.com" target="_blank">docs.staging.jujucharms.com</a></td>
-              <td class="image-tag">...</td>
-              <td class="commit">...</td>
-              <td class="human-time">...</td>
-              <td class="release">...</td>
-            </tr>
-            <tr data-domain="docs.maas.io">
-              <td><a href="https://docs.staging.maas.io" target="_blank">docs.staging.maas.io</a></td>
-              <td class="image-tag">...</td>
-              <td class="commit">...</td>
-              <td class="human-time">...</td>
-              <td class="release">...</td>
-            </tr>
-            <tr data-domain="docs.snapcraft.io">
-              <td><a href="https://docs.staging.snapcraft.io" target="_blank">docs.staging.snapcraft.io</a></td>
-              <td class="image-tag">...</td>
-              <td class="commit">...</td>
-              <td class="human-time">...</td>
-              <td class="release">...</td>
-            </tr>
             <tr data-domain="docs.ubuntu.com">
               <td><a href="https://docs.staging.ubuntu.com" target="_blank">docs.staging.ubuntu.com</a></td>
               <td class="image-tag">...</td>
@@ -254,9 +233,6 @@
     'conjure-up.io': 'canonical-web-and-design/conjure-up.io',
     'design.ubuntu.com': 'canonical-web-and-design/design.ubuntu.com',
     'docs.conjure-up.io': 'canonical-web-and-design/docs.conjure-up.io',
-    'docs.jujucharms.com': 'canonical-web-and-design/docs.jujucharms.com',
-    'docs.maas.io': 'CanonicalLtd/maas-docs',
-    'docs.snapcraft.io': 'canonical-web-and-design/docs.snapcraft.io',
     'docs.ubuntu.com': 'canonical-web-and-design/docs.ubuntu.com',
     'docs.vanillaframework.io': 'canonical-web-and-design/vanilla-framework',
     'engage.canonical.com': 'canonical-web-and-design/engage.canonical.com-public-cloud',


### PR DESCRIPTION
QA
--

`./run`, go to http://0.0.0.0:8103, see that `docs.maas.io`, `docs.snapcraft.io` and `docs.jujucharms.com` are no more.