### PR TITLE
Reduce docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -88,10 +88,17 @@ yarn.lock
 # Git, travis, docker
 .git
 .gitignore
+.circleci
+.codecov
+.github
 .travis.yml
 docker-compose.yml
 .docker
 Dockerfile
+
+# Environemnt
+.env
+.env.local
 
 # Sphinx documentation
 docs/_build/
@@ -101,6 +108,7 @@ docs/_build/
 node_modules/
 vendor/
 bower_components/
+package.json
 package-lock.json
 yarn.lock
 bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ ENV LANG C.UTF-8
 WORKDIR /srv
 
 # System dependencies
-RUN apt-get update && apt-get install --yes python3-pip
+RUN apt-get update && apt-get install -y --no-install-recommends python3 python3-setuptools python3-pip
 
 # Import code, install code dependencies
-ADD . .
-RUN pip3 install -r requirements.txt
+COPY . .
+RUN python3 -m pip install --no-cache-dir -r requirements.txt
 
 # Set git commit ID
 ARG TALISKER_REVISION_ID


### PR DESCRIPTION
Reduce size of docker image

## QA
- on `master` run `docker build --build-arg TALISKER_REVISION_ID=test -t releases.demo.haus:master .`
- checkout this feature branch
- run `docker build --build-arg TALISKER_REVISION_ID=test -t releases.demo.haus:feature .`
- run `docker images` and see the image tagged as `feature` is smaller than `master`
- run `docker run -ti -p 8103:80 releases.demo.haus:feature`
- browse localhost:8103 and make sure the site works