### PR TITLE
Multi-stage builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -81,9 +81,7 @@ run
 .*.hash
 
 # Node is only needed for building, not running
-package.json
 node_modules
-yarn.lock
 
 # Git, travis, docker
 .git
@@ -95,6 +93,9 @@ yarn.lock
 docker-compose.yml
 .docker
 Dockerfile
+renovate.json
+tests
+.sass-lint.yml
 
 # Environemnt
 .env
@@ -108,7 +109,4 @@ docs/_build/
 node_modules/
 vendor/
 bower_components/
-package.json
-package-lock.json
-yarn.lock
 bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,5 +27,3 @@ ENV TALISKER_REVISION_ID "${BUILD_ID}"
 # Setup commands to run server
 ENTRYPOINT ["./entrypoint"]
 CMD ["0.0.0.0:80"]
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,31 @@
-FROM ubuntu:bionic
+# syntax=docker/dockerfile:experimental
 
-# Set up environment
-ENV LANG C.UTF-8
-WORKDIR /srv
+# Build stage: Install python dependencies
+# ===
+FROM ubuntu:focal AS python-dependencies
+RUN apt-get update && apt-get install --no-install-recommends --yes python3 python3-setuptools python3-pip
+ADD requirements.txt /tmp/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip pip3 install --user --requirement /tmp/requirements.txt
 
-# System dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends python3 python3-setuptools python3-pip
+# Build the production image
+# ===
+FROM ubuntu:focal
 
-# Import code, install code dependencies
 COPY . .
-RUN python3 -m pip install --no-cache-dir -r requirements.txt
+# Install python and import python dependencies
+RUN apt-get update && apt-get install --no-install-recommends --yes python3 python3-setuptools
+COPY --from=python-dependencies /root/.local/lib/python3.8/site-packages /root/.local/lib/python3.8/site-packages
+COPY --from=python-dependencies /root/.local/bin /root/.local/bin
+ENV PATH="/root/.local/bin:${PATH}"
+RUN rm -rf package.json yarn.lock .babelrc webpack.config.js requirements.txt
 
 # Set git commit ID
-ARG TALISKER_REVISION_ID
-RUN test -n "${TALISKER_REVISION_ID}"
-ENV TALISKER_REVISION_ID "${TALISKER_REVISION_ID}"
+ARG BUILD_ID
+RUN test -n "${BUILD_ID}"
+ENV TALISKER_REVISION_ID "${BUILD_ID}"
 
 # Setup commands to run server
 ENTRYPOINT ["./entrypoint"]
 CMD ["0.0.0.0:80"]
+
+


### PR DESCRIPTION
## Done

Multistage builds to decrease image size, faster image building.

## QA

- `export DOCKER_BUILDKIT=1`
- Build image with new dockerfile `docker build --tag myimage --build-arg BUILD_ID=myfakeid .`
- Run conainter with this image `docker run -ti -p 8111:80 myimage`
- Check build_id `myfakeid` is present `curl localhost:8111`

## Issue / Card

Fixes #32 