### PR TITLE
add more random elements

### DIFF
--- a/templates/team/random.html
+++ b/templates/team/random.html
@@ -1,34 +1,48 @@
-{% extends "base.html" %}
+{% extends 'base.html' %}
 
-{% block description %}{% endblock %}
+{% block description %}
+
+{% endblock %}
 
 {% block content %}
-<section class="p-strip p-hero--home">
-  <div class="u-fixed-width">
-    <h1>{% block title %}Webteam randomizer{% endblock %}</h1>
-  </div>
-</section>
-
-<section>
-  <div class="row">
-    <div class="col-12">
-      <h2>Random webteam member</h2>
-      <p>{{ user }}</p>
-      <p><a href="https://en.wikipedia.org/wiki/Special:Random" class="p-button"><span>Random topic</span></a></p>
+  <section class="p-strip p-hero--home">
+    <div class="u-fixed-width">
+      <h1>
+        {% block title %}
+          Webteam randomizer
+        {% endblock %}
+      </h1>
     </div>
-  </div>
-</section>
+  </section>
 
-<section>
-  <div class="row">
-    <div class="col-12">
-      <h2>Random team order</h2>
-      <ol>
-        {% for team in teams %}
-          <li>{{ team }}</li>
-        {% endfor %}
+  <section>
+    <div class="row">
+      <div class="col-12">
+        <h2>Random webteam member</h2>
+        <p>{{ member.name }}</p>
+        <h2>Random designer</h2>
+        <p>{{ designer_member.name }}</p>
+        <h2>Random engineer</h2>
+        <p>{{ engineer_member.name }}</p>
+        <br />
+        <h2>Random topic</h2>
+        <p>
+          <a href="{{ topic.url }}">{{ topic.title }}</a>
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <div class="row">
+      <div class="col-12">
+        <h2>Random team order</h2>
+        <ol>
+          {% for team in teams %}
+            <li>{{ team }}</li>
+          {% endfor %}
         </ol>
+      </div>
     </div>
-  </div>
-</section>
-{% endblock content %}
+  </section>
+{% endblock %}

--- a/templates/team/random.html
+++ b/templates/team/random.html
@@ -27,7 +27,7 @@
         <br />
         <h2>Random topic</h2>
         <p>
-          <a href="{{ topic.url }}">{{ topic.title }}</a>
+          <a href="https://en.wikipedia.org/wiki/Special:Random">Wikipedia random article</a>
         </p>
       </div>
     </div>

--- a/webapp/team.py
+++ b/webapp/team.py
@@ -12,11 +12,6 @@ class TeamMember(TypedDict):
     username: str
 
 
-class WikipediaTopic(TypedDict):
-    title: str
-    url: str
-
-
 webteam = Blueprint(
     "webteam", __name__, template_folder="/templates", static_folder="/static"
 )

--- a/webapp/team.py
+++ b/webapp/team.py
@@ -1,19 +1,69 @@
 import random as rnd
+from typing import Any, List, TypedDict
+import requests
+from flask import Blueprint, jsonify, render_template, request
 from launchpadlib.launchpad import Launchpad
-from flask import Blueprint, render_template, request, jsonify
+
+from webapp.utils import lru_cache
+
+
+class TeamMember(TypedDict):
+    name: str
+    username: str
+
+
+class WikipediaTopic(TypedDict):
+    title: str
+    url: str
+
 
 webteam = Blueprint(
     "webteam", __name__, template_folder="/templates", static_folder="/static"
 )
 
 
-def get_all_display_names():
-    lp = Launchpad.login_anonymously(
+def lp_instance():
+    return Launchpad.login_anonymously(
         "webteam.canonical.com", "production", ".", version="devel"
     )
-    team = lp.people["canonical-webmonkeys"]
 
-    return [person.display_name for person in team.members]
+
+def map_person(person: Any) -> TeamMember:
+    return {
+        "name": person.display_name,
+        "username": person.name,
+    }
+
+
+@lru_cache(ttl_seconds=60 * 10)
+def get_team_members(team_name: str) -> List[TeamMember]:
+    lp = lp_instance()
+    team = lp.people[team_name]
+    members = [map_person(person) for person in team.members]
+    members.sort(key=lambda x: x["name"])
+    return members
+
+
+def exclude_team_members(
+    team: List[TeamMember], exclude: List[str]
+) -> List[TeamMember]:
+    exclude_set = set([member["username"] for member in exclude])
+    all_set = set([member["username"] for member in team])
+    map_username = {member["username"]: member for member in team}
+    return [map_username[username] for username in all_set - exclude_set]
+
+
+@lru_cache(ttl_seconds=5)
+def random_wikipedia_topic() -> WikipediaTopic:
+    random_topic = "https://en.wikipedia.org/wiki/Special:Random"
+    response = requests.request("GET", random_topic)
+    topic_url = response.url
+    # <title>{title}</title>
+    topic_title = response.text.split("<title>")[1].split("</title>")[0]
+    return {
+        "title": topic_title,
+        "url": topic_url,
+    }
 
 
 def get_all_teams():
@@ -33,50 +83,27 @@ def get_all_teams():
     ]
 
 
-def get_all_mattermost_handles():
-    lp = Launchpad.login_anonymously(
-        "webteam.canonical.com", "production", ".", version="devel"
-    )
-    team = lp.people["canonical-webmonkeys"]
-
-    return [person.name for person in team.members]
-
-
 @webteam.route("/")
 def index():
-    display_names = get_all_display_names()
-    display_names.sort()
-
+    all_members_names = [
+        member["name"] for member in get_team_members("canonical-webmonkeys")
+    ]
     if request.headers.get(
         "Content-Type"
     ) and "application/json" in request.headers.get("Content-Type"):
-        return jsonify(display_names)
+        return jsonify(all_members_names)
     else:
-        return render_template("team/index.html", display_names=display_names)
-
-
-@webteam.route("/random")
-def random():
-    display_names = get_all_display_names()
-    team_names = get_all_teams()
-
-    context = {
-        "user": rnd.choice(display_names),
-        "teams": rnd.sample(team_names, len(team_names)),
-    }
-
-    if request.headers.get(
-        "Content-Type"
-    ) and "application/json" in request.headers.get("Content-Type"):
-        return jsonify(context)
-    else:
-        return render_template("team/random.html", **context)
+        return render_template(
+            "team/index.html", display_names=all_members_names
+        )
 
 
 @webteam.route("/mattermost")
 def mattermost():
-    mattermost_handles = get_all_mattermost_handles()
-    mattermost_handles.sort()
+    mattermost_handles = [
+        person["username"]
+        for person in get_team_members("canonical-webmonkeys")
+    ]
 
     if request.headers.get(
         "Content-Type"
@@ -86,6 +113,29 @@ def mattermost():
         return render_template(
             "team/mattermost.html", mattermost_handles=mattermost_handles
         )
+
+
+@webteam.route("/random")
+def random():
+    all_members = get_team_members("canonical-webmonkeys")
+    engineers = get_team_members("canonical-web-engineers")
+    designers = exclude_team_members(all_members, engineers)
+    team_names = get_all_teams()
+
+    context = {
+        "member": rnd.choice(all_members),
+        "engineer_member": rnd.choice(engineers),
+        "designer_member": rnd.choice(designers),
+        "topic": random_wikipedia_topic(),
+        "teams": rnd.sample(team_names, len(team_names)),
+    }
+
+    if request.headers.get(
+        "Content-Type"
+    ) and "application/json" in request.headers.get("Content-Type"):
+        return jsonify(context)
+    else:
+        return render_template("team/random.html", **context)
 
 
 @webteam.after_request

--- a/webapp/team.py
+++ b/webapp/team.py
@@ -1,7 +1,6 @@
 import random as rnd
 from typing import Any, List, TypedDict
 
-import requests
 from flask import Blueprint, jsonify, render_template, request
 from launchpadlib.launchpad import Launchpad
 

--- a/webapp/team.py
+++ b/webapp/team.py
@@ -1,5 +1,6 @@
 import random as rnd
 from typing import Any, List, TypedDict
+
 import requests
 from flask import Blueprint, jsonify, render_template, request
 from launchpadlib.launchpad import Launchpad
@@ -51,19 +52,6 @@ def exclude_team_members(
     all_set = set([member["username"] for member in team])
     map_username = {member["username"]: member for member in team}
     return [map_username[username] for username in all_set - exclude_set]
-
-
-@lru_cache(ttl_seconds=5)
-def random_wikipedia_topic() -> WikipediaTopic:
-    random_topic = "https://en.wikipedia.org/wiki/Special:Random"
-    response = requests.request("GET", random_topic)
-    topic_url = response.url
-    # <title>{title}</title>
-    topic_title = response.text.split("<title>")[1].split("</title>")[0]
-    return {
-        "title": topic_title,
-        "url": topic_url,
-    }
 
 
 def get_all_teams():
@@ -126,7 +114,6 @@ def random():
         "member": rnd.choice(all_members),
         "engineer_member": rnd.choice(engineers),
         "designer_member": rnd.choice(designers),
-        "topic": random_wikipedia_topic(),
         "teams": rnd.sample(team_names, len(team_names)),
     }
 

--- a/webapp/utils.py
+++ b/webapp/utils.py
@@ -1,0 +1,18 @@
+import time
+from functools import lru_cache as _lru_cache
+
+
+def lru_cache(*, ttl_seconds, maxsize=128):
+    def deco(foo):
+        @_lru_cache(maxsize=maxsize)
+        def cached_with_ttl(*args, ttl_hash, **kwargs):
+            return foo(*args, **kwargs)
+
+        def inner(*args, **kwargs):
+            return cached_with_ttl(
+                *args, ttl_hash=round(time.time() / ttl_seconds), **kwargs
+            )
+
+        return inner
+
+    return deco


### PR DESCRIPTION
## Done

- Add more specific random members types: engineers (LP team `canonical-web-engineers`), designers (`canonical-webmonkeys - canonical-web-engineers`)

## QA

- Go to https://webteam-canonical-com-187.demos.haus/team/random
  - Make sure that the random member picker is working as expected
  - Refresh the page
  - Make sure that the list of members has changed
- Go to https://webteam-canonical-com-187.demos.haus/team/mattermost
  - Make sure that it works as before (shows the list of member's Mattermost username)
- Go to https://webteam-canonical-com-187.demos.haus/team
  - Make sure that it works as before (shows the list of members name)