### PR TITLE
chore: update favicon

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -5,7 +5,10 @@
   <title>{% block title%}Web & Design portal{% endblock %}</title>
   <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static('css/styles.css') }}">
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link rel="shortcut icon" href="https://assets.ubuntu.com/v1/0843d517-favicon.ico" type="image/x-icon" />
+  <link rel="icon"
+          type="image/png"
+          sizes="32x32"
+          href="https://assets.ubuntu.com/v1/be7e4cc6-COF-favicon-32x32.png" />
 </head>
 
 <body>


### PR DESCRIPTION
Updated favicon on the web team portal to latest

QA
- Go to the demo and view the favicon
- It should be same as ubuntu.com or canonical.com
